### PR TITLE
Remove n8n-core from dependancies into peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": "*",
+    "n8n-core": "*"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.18",
-    "n8n-core": "^1.14.1"
+    "@atproto/api": "^0.13.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^0.13.18
         version: 0.13.18
       n8n-core:
-        specifier: ^1.14.1
+        specifier: '*'
         version: 1.14.1(n8n-nodes-base@1.14.1(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0))(asn1.js@5.4.1)(promise-ftp-common@1.1.5))
     devDependencies:
       '@typescript-eslint/parser':
@@ -8575,7 +8575,7 @@ snapshots:
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
-      string_decoder: 1.1.1
+      string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
   readable-stream@4.5.2:


### PR DESCRIPTION
When starting up n8n I get
```
Initializing n8n process
nodes package n8n-nodes-base is already loaded.
 Please delete this second copy at path /home/node/.n8n/nodes/node_modules/n8n-nodes-base
nodes package n8n-nodes-base is already loaded.
 Please delete this second copy at path /home/node/.n8n/nodes/node_modules/n8n-nodes-base
Error: nodes package n8n-nodes-base is already loaded.
 Please delete this second copy at path /home/node/.n8n/nodes/node_modules/n8n-nodes-base
```