### PR TITLE
Fix: Default embed description to empty string if not in Open Graph tags

### DIFF
--- a/nodes/Bluesky/V2/__tests__/postOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/postOperations.test.ts
@@ -1,0 +1,59 @@
+import { postOperation } from '../postOperations';
+import ogs from 'open-graph-scraper';
+import { AtpAgent } from '@atproto/api';
+
+jest.mock('open-graph-scraper');
+jest.mock('@atproto/api');
+
+describe('postOperation', () => {
+	let mockAgent: jest.Mocked<AtpAgent>;
+
+	beforeEach(() => {
+		// Reset mocks before each test
+		(ogs as jest.Mock).mockReset();
+
+		// Mock AtpAgent and its methods
+		mockAgent = {
+			post: jest.fn().mockResolvedValue({ uri: 'test-uri', cid: 'test-cid' }),
+			uploadBlob: jest.fn().mockResolvedValue({ data: { blob: 'test-blob' } }),
+		} as any; // Using 'any' to simplify mock structure for methods not directly used by postOperation's core logic being tested
+	});
+
+	it('should set description to empty string if ogDescription is missing when fetching Open Graph tags', async () => {
+		(ogs as jest.Mock).mockResolvedValue({
+			error: false,
+			result: {
+				ogTitle: 'Test Title',
+				// ogDescription is intentionally missing
+				ogImage: [{ url: 'http://example.com/image.png' }],
+				success: true,
+			},
+		});
+
+		// Mock fetch for image data
+		global.fetch = jest.fn().mockResolvedValue({
+			ok: true,
+			statusText: 'OK',
+			arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+		} as any);
+
+		const postText = 'Test post';
+		const langs = ['en'];
+		const websiteCard = {
+			uri: 'http://example.com',
+			fetchOpenGraphTags: true,
+			title: '', // Title will be overridden by OG data
+			description: 'Initial Description', // This should be overridden
+			thumbnailBinary: undefined,
+		};
+
+		await postOperation(mockAgent, postText, langs, websiteCard);
+
+		expect(mockAgent.post).toHaveBeenCalledTimes(1);
+		const postData = mockAgent.post.mock.calls[0][0];
+		expect(postData.embed).toBeDefined();
+		expect(postData.embed.external).toBeDefined();
+		expect(postData.embed.external.description).toBe('');
+		expect(postData.embed.external.title).toBe('Test Title'); // Ensure title is still set
+	});
+});

--- a/nodes/Bluesky/V2/postOperations.ts
+++ b/nodes/Bluesky/V2/postOperations.ts
@@ -232,6 +232,8 @@ export async function postOperation(
 			}
 			if (ogsResponse.result.ogDescription) {
 				websiteCard.description = ogsResponse.result.ogDescription;
+			} else {
+				websiteCard.description = '';
 			}
 		}
 


### PR DESCRIPTION
When fetching Open Graph (OG) tags for a URL to create an embed card, the `description` field was not being defaulted if `ogDescription` was missing from the fetched tags. This would lead to an error: "Invalid app.bsky.feed.post record: Record/embed/external must have the property 'description'".

This commit modifies the `postOperation` function to ensure that if `ogDescription` is not found in the OG tags, the `embed.external.description` defaults to an empty string.

A new test case has been added to `nodes/Bluesky/V2/__tests__/postOperations.test.ts` to specifically verify this fix. The test simulates a scenario where `ogDescription` is not returned, and asserts that the `description` field in the Bluesky post data is an empty string.