### PR TITLE
feat: Add OAuth2 support and fix App Password for custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,45 @@ pnpm install @muench-dev/n8n-nodes-bluesky
 
 In n8n community edition, you can install the nodes in the settings page.
 
+## Authentication
+
+This node supports two methods of authentication: App Password and OAuth2 (Beta).
+
+### OAuth2 Authentication (Beta/Experimental)
+
+This method is being introduced in anticipation of Bluesky's official OAuth2 support. Its full functionality is dependent on Bluesky finalizing its OAuth2 implementation and providing a way for applications to register for Client IDs and Secrets.
+
+**Steps to configure:**
+
+1.  Create new credentials in n8n: Go to the "Credentials" section, click "Add credential", and search for/select "Bluesky OAuth2 API".
+2.  **Client ID**: Enter the Client ID obtained from Bluesky for your n8n application. (Details pending Bluesky's official documentation for app registration).
+3.  **Client Secret**: Enter the Client Secret obtained from Bluesky.
+4.  **Authorization URL**: This is the URL where you will be redirected to authorize the application. It's currently pre-filled with a placeholder (`https://bsky.social/oauth/authorize`) and will be updated once Bluesky provides the official URL.
+5.  **Access Token URL**: This is the URL from which n8n will fetch the access token. It's currently pre-filled with a placeholder (`https://bsky.social/oauth/token`) and will be updated once Bluesky provides the official URL.
+6.  **Scope**: The default scopes requested are `read write profile feed`. These define the permissions your n8n workflow will have. These may be subject to change based on Bluesky's implementation.
+
+**Note:** Full functionality of OAuth2 authentication is pending Bluesky's finalization of its OAuth2 endpoints and app registration process. The current setup uses placeholder URLs.
+
+In the Bluesky node configuration within your n8n workflow, select "OAuth2" as the "Authentication Type" and choose your created "Bluesky OAuth2 API" credential.
+
+### App Password Authentication (Legacy/Alternative)
+
+This method uses your Bluesky handle and an App Password.
+
+**Credential Fields:**
+
+1.  Create new credentials in n8n: Go to the "Credentials" section, click "Add credential", and search for/select "Bluesky API".
+2.  **Identifier (Handle)**: Your Bluesky handle (e.g., `yourname.bsky.social` or `your.customdomain.com`).
+3.  **App Password**: Your Bluesky App Password. You can create one in your Bluesky account settings.
+4.  **Service URL**: The URL of your AT Protocol service. Defaults to `https://bsky.social`.
+    *   For most users, the default `https://bsky.social` will work.
+    *   If you use a custom domain for your handle (e.g., `your.customdomain.com`) AND experience issues with the default Service URL (especially if your account is hosted on a PDS other than bsky.social), try providing the URL of your specific PDS (Personal Data Server) here (e.g., `https://pds.example.com`).
+    *   The node attempts to resolve handles to their DIDs automatically, which should work in most cases even with custom domains using the default service URL. Providing the specific PDS URL is a fallback if resolution issues occur.
+
+**Note:** This method remains available. For users with custom domains, the node now includes improved handle resolution to automatically find your account's DID.
+
+In the Bluesky node configuration within your n8n workflow, select "App Password" as the "Authentication Type" and choose your created "Bluesky API" credential.
+
 ## Features
 
 - User
@@ -19,15 +58,17 @@ In n8n community edition, you can install the nodes in the settings page.
 	- Get Profile
 	- Mute User
 	- Un-mute User
+	- Unblock User
 - Feed
 	- Get Author Feed
 	- Get Timeline of current user
 - Post
 	- Create Post
-  - Like
-  - Unlike
-  - Repost
-  - Delete Repost
+	- Delete Post
+	- Like Post
+	- Delete Like
+	- Repost
+	- Delete Repost
 
 ## Screenshots
 
@@ -44,3 +85,7 @@ You can use the RSS Trigger node to get the latest posts from an RSS feed and th
 Use Open Graph Tags to get the image and description of the post.
 
 ![images](.github/images/use_case_rss_trigger_node_details.png)
+
+## Development
+
+Follow the [n8n documentation for creating nodes](https://docs.n8n.io/integrations/creating-nodes/build/node-development-setup/).

--- a/credentials/BlueskyOAuth2Api.credentials.ts
+++ b/credentials/BlueskyOAuth2Api.credentials.ts
@@ -1,43 +1,44 @@
 // TODO: Update placeholder URLs and scopes once the correct information is found.
 
-import { IAuthOAuth2, ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class BlueskyOAuth2Api implements ICredentialType {
 	name = 'blueskyOAuth2Api';
+	extends = ['oAuth2Api'];
 	displayName = 'Bluesky OAuth2 API';
-	documentationUrl = 'https://github.com/MarynaCherniavska/n8n-nodes-bluesky/blob/main/README.md'; // TODO: update with actual documentation URL
-	properties = [
+	documentationUrl = 'https://docs.bsky.app/docs/advanced-guides/oauth-client';
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Grant Type',
 			name: 'grantType',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'authorizationCode',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://bsky.social/oauth/authorize', // Placeholder
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://bsky.social/oauth/token', // Placeholder
 			required: true,
 		},
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -47,28 +48,20 @@ export class BlueskyOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'read write profile feed', // Common scopes
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];
-	authenticate = {
-		type: 'oauth2',
-		oAuth2Options: {
-			includeCredentialsOnRefresh: true,
-			authCodeGrantType: 'authorizationCode',
-			pkce: true, // Enable PKCE
-		},
-	} as IAuthOAuth2;
 }

--- a/credentials/BlueskyOAuth2Api.credentials.ts
+++ b/credentials/BlueskyOAuth2Api.credentials.ts
@@ -1,0 +1,74 @@
+// TODO: Update placeholder URLs and scopes once the correct information is found.
+
+import { IAuthOAuth2, ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+
+export class BlueskyOAuth2Api implements ICredentialType {
+	name = 'blueskyOAuth2Api';
+	displayName = 'Bluesky OAuth2 API';
+	documentationUrl = 'https://github.com/MarynaCherniavska/n8n-nodes-bluesky/blob/main/README.md'; // TODO: update with actual documentation URL
+	properties = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden' as NodePropertyTypes,
+			default: 'authorizationCode',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'string' as NodePropertyTypes,
+			default: 'https://bsky.social/oauth/authorize', // Placeholder
+			required: true,
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'string' as NodePropertyTypes,
+			default: 'https://bsky.social/oauth/token', // Placeholder
+			required: true,
+		},
+		{
+			displayName: 'Client ID',
+			name: 'clientId',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+			required: true,
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			required: true,
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'string' as NodePropertyTypes,
+			default: 'read write profile feed', // Common scopes
+		},
+		{
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden' as NodePropertyTypes,
+			default: '',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden' as NodePropertyTypes,
+			default: 'body',
+		},
+	];
+	authenticate = {
+		type: 'oauth2',
+		oAuth2Options: {
+			includeCredentialsOnRefresh: true,
+			authCodeGrantType: 'authorizationCode',
+			pkce: true, // Enable PKCE
+		},
+	} as IAuthOAuth2;
+}

--- a/nodes/Bluesky/Bluesky.node.ts
+++ b/nodes/Bluesky/Bluesky.node.ts
@@ -14,6 +14,44 @@ export class Bluesky extends VersionedNodeType {
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Interact with the Bluesky social platform',
 			defaultVersion: 2,
+			credentials: [
+				{
+					name: 'blueskyApi',
+					required: true,
+					displayOptions: {
+						show: {
+							authType: ['appPassword'],
+						},
+					},
+				},
+				{
+					name: 'blueskyOAuth2Api',
+					required: true,
+					displayOptions: {
+						show: {
+							authType: ['oAuth2'],
+						},
+					},
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication Type',
+					name: 'authType',
+					type: 'options',
+					options: [
+						{
+							name: 'App Password',
+							value: 'appPassword',
+						},
+						{
+							name: 'OAuth2',
+							value: 'oAuth2',
+						},
+					],
+					default: 'appPassword',
+				},
+			],
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {

--- a/nodes/Bluesky/Bluesky.node.ts
+++ b/nodes/Bluesky/Bluesky.node.ts
@@ -14,44 +14,6 @@ export class Bluesky extends VersionedNodeType {
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Interact with the Bluesky social platform',
 			defaultVersion: 2,
-			credentials: [
-				{
-					name: 'blueskyApi',
-					required: true,
-					displayOptions: {
-						show: {
-							authType: ['appPassword'],
-						},
-					},
-				},
-				{
-					name: 'blueskyOAuth2Api',
-					required: true,
-					displayOptions: {
-						show: {
-							authType: ['oAuth2'],
-						},
-					},
-				},
-			],
-			properties: [
-				{
-					displayName: 'Authentication Type',
-					name: 'authType',
-					type: 'options',
-					options: [
-						{
-							name: 'App Password',
-							value: 'appPassword',
-						},
-						{
-							name: 'OAuth2',
-							value: 'oAuth2',
-						},
-					],
-					default: 'appPassword',
-				},
-			],
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {

--- a/nodes/Bluesky/Bluesky.node.ts
+++ b/nodes/Bluesky/Bluesky.node.ts
@@ -13,12 +13,13 @@ export class Bluesky extends VersionedNodeType {
 			group: ['transform'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Interact with the Bluesky social platform',
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new BlueskyV1(baseDescription),
 			2: new BlueskyV2(baseDescription),
+			2.1: new BlueskyV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -4,7 +4,7 @@ import type {
 	INodeType,
 	INodeTypeDescription,
 	LoggerProxy as Logger,
-	INodeTypeBaseDescription, JsonObject, NodeApiError, INodeCredentialDescription, NodeDefaults,
+	INodeTypeBaseDescription, INodeCredentialDescription, NodeDefaults,
 } from 'n8n-workflow';
 
 import { NodeConnectionType } from 'n8n-workflow';

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -3,8 +3,8 @@ import type {
 	IExecuteFunctions,
 	INodeType,
 	INodeTypeDescription,
-	INodeTypeBaseDescription, JsonObject, NodeApiError,
 	LoggerProxy as Logger,
+	INodeTypeBaseDescription, JsonObject, NodeApiError, INodeCredentialDescription, NodeDefaults,
 } from 'n8n-workflow';
 
 import { NodeConnectionType } from 'n8n-workflow';
@@ -43,7 +43,8 @@ export class BlueskyV2 implements INodeType {
 			version: 2,
 			defaults: {
 				name: 'Bluesky',
-			},
+			} as NodeDefaults,
+			usableAsTool: true,
 			inputs: [NodeConnectionType.Main],
 			outputs: [NodeConnectionType.Main],
 			properties: [credentialTypeProperty, resourcesProperty, ...userProperties, ...postProperties, ...feedProperties],
@@ -69,7 +70,7 @@ export class BlueskyV2 implements INodeType {
 					},
 				} as INodeCredentialDescription,
 			] as INodeCredentialDescription[],
-		};
+		} as INodeTypeDescription;
 	}
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
@@ -419,8 +420,6 @@ export class BlueskyV2 implements INodeType {
 				throw new NodeApiError(this.getNode(), error as JsonObject);
 			}
 		}
-
-		Logger.info('Node execution finished', { ...nodeMeta, itemsProcessed: items.length, itemsReturned: returnData.length });
 
 		return [returnData];
 	}

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -40,14 +40,13 @@ export class BlueskyV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: 2,
+			version: [2, 2.1],
 			defaults: {
 				name: 'Bluesky',
 			} as NodeDefaults,
 			usableAsTool: true,
 			inputs: [NodeConnectionType.Main],
 			outputs: [NodeConnectionType.Main],
-			properties: [credentialTypeProperty, resourcesProperty, ...userProperties, ...postProperties, ...feedProperties],
 			credentials: [
 				{
 					name: 'blueskyApi',
@@ -55,6 +54,17 @@ export class BlueskyV2 implements INodeType {
 					required: true,
 					displayOptions: {
 						show: {
+							'@version': [2],
+						},
+					},
+				} as INodeCredentialDescription,
+				{
+					name: 'blueskyApi',
+					displayName: 'Bluesky API (App Password)',
+					required: true,
+					displayOptions: {
+						show: {
+							'@version': [2.1],
 							credentialType: ['appPassword'],
 						},
 					},
@@ -65,11 +75,13 @@ export class BlueskyV2 implements INodeType {
 					required: true,
 					displayOptions: {
 						show: {
+							'@version': [2.1],
 							credentialType: ['oAuth2'],
 						},
 					},
 				} as INodeCredentialDescription,
 			] as INodeCredentialDescription[],
+			properties: [credentialTypeProperty, resourcesProperty, ...userProperties, ...postProperties, ...feedProperties],
 		} as INodeTypeDescription;
 	}
 

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -75,12 +75,10 @@ export class BlueskyV2 implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
-		const credentialType = this.getNodeParameter('credentialType', 0) as string;
+		const credentialType = this.getNodeParameter('credentialType', 0) as string | 'appPassword';
 
 		let agent: AtpAgent;
 		const operation = this.getNodeParameter('operation', 0) as string;
-
-		console.log(credentialType);
 
 		if (credentialType === 'appPassword') {
 			const credentials = (await this.getCredentials('blueskyApi')) as {

--- a/nodes/Bluesky/V2/credentialTypes.ts
+++ b/nodes/Bluesky/V2/credentialTypes.ts
@@ -1,0 +1,19 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const credentialTypeProperty: INodeProperties = {
+	displayName: 'Credential Type',
+	name: 'credentialType',
+	type: 'options',
+	noDataExpression: true,
+	options: [
+		{
+			name: 'Bluesky appPassword',
+			value: 'appPassword',
+		},
+		{
+			name: 'Bluesky OAuth2 API',
+			value: 'oAuth2',
+		},
+	],
+	default: 'appPassword',
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "n8n": {
     "n8nNodesApiVersion": 1,
     "credentials": [
-      "dist/credentials/BlueskyApi.credentials.js"
+      "dist/credentials/BlueskyApi.credentials.js",
+      "dist/credentials/BlueskyOAuth2Api.credentials.js"
     ],
     "nodes": [
       "dist/nodes/Bluesky/Bluesky.node.js"


### PR DESCRIPTION
I've implemented an OAuth2 authentication flow for Bluesky nodes:
- I added `BlueskyOAuth2Api.credentials.ts` for OAuth2 credential management, including PKCE support (using placeholder URLs pending Bluesky's official release).
- I updated `Bluesky.node.ts` and `BlueskyV2.node.ts` to integrate the new OAuth2 credential type and handle token-based authentication.

I also improved App Password authentication for users with custom domains:
- I modified `BlueskyV2.node.ts` to pre-resolve handles to DIDs before attempting login. This enhances reliability for custom domain users by ensuring the correct identifier is used with their PDS.
- I added logging for the resolution process.

Finally, I updated `README.md` to:
- Document the new OAuth2 authentication method (Beta).
- Provide clearer instructions for App Password authentication, especially regarding the `Service URL` for custom domain users.

---

Hopefully solves: #81