### PR TITLE
feat: Enhance error handling and add card fetch fallback

### DIFF
--- a/nodes/Bluesky/V2/BlueskyV2.node.test.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.test.ts
@@ -1,0 +1,214 @@
+import { AtpAgent } from '@atproto/api';
+import { IExecuteFunctions, INodeExecutionData, NodeOperationError } from 'n8n-workflow';
+import { BlueskyV2 } from './BlueskyV2.node';
+
+// Mock AtpAgent methods
+jest.mock('@atproto/api', () => {
+	const actualApi = jest.requireActual('@atproto/api');
+	return {
+		...actualApi,
+		AtpAgent: jest.fn().mockImplementation(() => ({
+			login: jest.fn().mockResolvedValue(undefined),
+			post: jest.fn(), // Will be further mocked in tests
+			// Add other methods as needed by operations
+			deletePost: jest.fn(),
+			like: jest.fn(),
+			deleteLike: jest.fn(),
+			repost: jest.fn(),
+			deleteRepost: jest.fn(),
+			getProfile: jest.fn(),
+			mute: jest.fn(),
+			unmute: jest.fn(),
+			block: jest.fn(),
+			unblock: jest.fn(),
+			getAuthorFeed: jest.fn(),
+			getTimeline: jest.fn(),
+		})),
+		CredentialSession: jest.fn().mockImplementation(() => ({})),
+	};
+});
+
+
+describe('BlueskyV2 Node', () => {
+	let executeFunctions: IExecuteFunctions;
+	let blueskyNodeInstance: BlueskyV2;
+
+	beforeEach(() => {
+		// Reset mocks for each test
+		jest.clearAllMocks();
+
+		// Mock IExecuteFunctions
+		executeFunctions = {
+			getInputData: jest.fn().mockReturnValue([]),
+			getCredentials: jest.fn().mockResolvedValue({
+				identifier: 'testUser',
+				appPassword: 'testPassword',
+				serviceUrl: 'https://bsky.social',
+			}),
+			getNodeParameter: jest.fn(),
+			getURL: jest.fn(),
+			helpers: {
+				executionApi: {
+					addExecutionError: jest.fn(),
+				},
+				getBinaryDataBuffer: jest.fn(),
+			},
+			getNode: jest.fn().mockReturnValue({
+				// Mock a minimal node structure
+				name: 'Bluesky Test Node',
+				type: 'BlueskyV2',
+				typeVersion: 2,
+				position: [0,0],
+				id: 'test-node-id'
+			}),
+			continueOnFail: jest.fn().mockReturnValue(false), // Default to false
+		} as unknown as IExecuteFunctions;
+
+		// Instantiate the node. Adjust constructor params if baseDescription is more complex.
+		blueskyNodeInstance = new BlueskyV2({
+			displayName: 'Bluesky Test',
+			name: 'BlueskyV2',
+			group: ['social media'],
+			version: 1, // Example version
+			description: 'Test Bluesky Node',
+			defaults: { name: 'Bluesky' },
+			inputs: ['main'],
+			outputs: ['main'],
+			credentials: [{ name: 'blueskyApi', required: true }],
+			properties: [], // Simplified for testing core logic
+		});
+
+		// Mock AtpAgent instance for direct access if needed by operations
+		// (though operations are mostly self-contained after agent init)
+		// mockedAgentInstance = new AtpAgent();
+	});
+
+	describe('execute method error handling', () => {
+		it('should re-throw error if operation fails and continueOnFail is false', async () => {
+			const mockError = new Error('Operation failed');
+			const inputItem: INodeExecutionData = { json: { text: 'Test post' } };
+
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([inputItem]);
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockImplementation((paramName: string, itemIndex: number) => {
+					if (paramName === 'operation') return 'post';
+					if (paramName === 'postText') return 'Test post text';
+					if (paramName === 'langs') return ['en'];
+					return undefined;
+			});
+			(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(false);
+
+			// Mock the 'post' operation within AtpAgent to throw an error
+			const mockedAgentPost = AtpAgent.prototype.post as jest.Mock;
+			mockedAgentPost.mockRejectedValue(mockError);
+
+
+			await expect(blueskyNodeInstance.execute.call(executeFunctions)).rejects.toThrow(mockError.message);
+
+			expect(executeFunctions.helpers.executionApi.addExecutionError).toHaveBeenCalledTimes(1);
+			expect(executeFunctions.helpers.executionApi.addExecutionError).toHaveBeenCalledWith(
+				expect.any(NodeOperationError), // Or expect.any(Error) if that's what's thrown by the node before wrapping
+			);
+			// More detailed check for NodeOperationError
+			const errorCall = (executeFunctions.helpers.executionApi.addExecutionError as jest.Mock).mock.calls[0][0];
+			expect(errorCall).toBeInstanceOf(NodeOperationError);
+			expect(errorCall.message).toContain("Failed to process item 0 for operation 'post': Operation failed");
+			expect(errorCall.node).toEqual(executeFunctions.getNode());
+			expect(errorCall.itemDetails).toEqual(inputItem.json);
+		});
+
+		it('should not re-throw error if operation fails and continueOnFail is true, returning empty for the item', async () => {
+			const mockError = new Error('Operation failed again');
+			const inputItem: INodeExecutionData = { json: { text: 'Another test post' } };
+
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([inputItem]);
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockImplementation((paramName: string, itemIndex: number) => {
+					if (paramName === 'operation') return 'post';
+					if (paramName === 'postText') return 'Test post text for continueOnFail';
+					if (paramName === 'langs') return ['en'];
+					return undefined;
+				});
+			(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
+
+			// Mock the 'post' operation to throw an error
+			const mockedAgentPost = AtpAgent.prototype.post as jest.Mock;
+			mockedAgentPost.mockRejectedValue(mockError);
+
+			const result = await blueskyNodeInstance.execute.call(executeFunctions);
+
+			expect(result).toEqual([[]]); // Expecting an empty array for the failed item's execution path.
+			                               // If the node returns INodeExecutionData[][], and one item fails, it should be [[]]
+			                               // If it's structured per item, it might be different, e.g. [{json: {}, error: ...}]
+			                               // Based on current BlueskyV2.node.ts, it returns [returnData] where returnData is flat.
+			                               // If an item fails and continueOnFail is true, it's skipped from returnData.
+			                               // So if 1 item is input and it fails, returnData is [], so result is [[]].
+
+			expect(executeFunctions.helpers.executionApi.addExecutionError).toHaveBeenCalledTimes(1);
+			const errorCall = (executeFunctions.helpers.executionApi.addExecutionError as jest.Mock).mock.calls[0][0];
+			expect(errorCall).toBeInstanceOf(NodeOperationError);
+			expect(errorCall.message).toContain("Failed to process item 0 for operation 'post': Operation failed again");
+			expect(errorCall.node).toEqual(executeFunctions.getNode());
+			expect(errorCall.itemDetails).toEqual(inputItem.json);
+
+			// Ensure error is not re-thrown (implicitly tested by not using .rejects and .toThrow)
+		});
+
+		it('should handle multiple items with one error correctly when continueOnFail is true', async () => {
+			const mockError = new Error('Specific item operation failed');
+			const inputItems: INodeExecutionData[] = [
+				{ json: { id: 'item1-success', text: 'Successful post' } },
+				{ json: { id: 'item2-failure', text: 'Failed post attempt' } },
+				{ json: { id: 'item3-success', text: 'Another successful post' } },
+			];
+			const successfulPostResult1 = { uri: 'at://did:plc:123/app.bsky.feed.post/success1', cid: 'bafysuccess1' };
+			const successfulPostResult3 = { uri: 'at://did:plc:123/app.bsky.feed.post/success3', cid: 'bafysuccess3' };
+
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue(inputItems);
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockImplementation((paramName: string, itemIndex: number) => {
+					if (paramName === 'operation') return 'post';
+					if (paramName === 'postText') return inputItems[itemIndex].json.text;
+					if (paramName === 'langs') return ['en'];
+					return undefined;
+				});
+			(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
+
+			// Mock AtpAgent's post method
+			const mockedAgentPost = AtpAgent.prototype.post as jest.Mock;
+			mockedAgentPost
+				.mockResolvedValueOnce(successfulPostResult1) // For item 0 (item1-success)
+				.mockRejectedValueOnce(mockError)             // For item 1 (item2-failure)
+				.mockResolvedValueOnce(successfulPostResult3); // For item 2 (item3-success)
+
+			const result = await blueskyNodeInstance.execute.call(executeFunctions);
+
+			// Assertions
+			expect(executeFunctions.helpers.executionApi.addExecutionError).toHaveBeenCalledTimes(1);
+			const errorCall = (executeFunctions.helpers.executionApi.addExecutionError as jest.Mock).mock.calls[0][0];
+			expect(errorCall).toBeInstanceOf(NodeOperationError);
+			// Note: The item index in the error message is the original index from the inputItems array.
+			expect(errorCall.message).toContain("Failed to process item 1 for operation 'post': Specific item operation failed");
+			expect(errorCall.itemDetails).toEqual(inputItems[1].json); // Error associated with the second item
+
+			// Check returned data: should contain results for successful items only
+			// The structure of returnData is INodeExecutionData[] which is then wrapped in an array by execute method: [returnData]
+			expect(result).toEqual([
+				[
+					{ json: successfulPostResult1 }, // Result for item 0
+					{ json: successfulPostResult3 }, // Result for item 2
+				],
+			]);
+
+			// Ensure post was called for all items
+			expect(mockedAgentPost).toHaveBeenCalledTimes(3);
+			expect(mockedAgentPost).toHaveBeenNthCalledWith(1, expect.objectContaining({ text: inputItems[0].json.text }));
+			expect(mockedAgentPost).toHaveBeenNthCalledWith(2, expect.objectContaining({ text: inputItems[1].json.text }));
+			expect(mockedAgentPost).toHaveBeenNthCalledWith(3, expect.objectContaining({ text: inputItems[2].json.text }));
+		});
+	});
+});
+
+// Helper to properly type AtpAgent mock for direct method mocking if needed elsewhere
+// const mockedAgentInstance = new AtpAgent() as jest.Mocked<AtpAgent>;
+// For example: mockedAgentInstance.post.mockResolvedValue({ uri: 'at://did:plc:123/app.bsky.feed.post/abc', cid: 'bafy...' });

--- a/nodes/Bluesky/V2/postOperations.test.ts
+++ b/nodes/Bluesky/V2/postOperations.test.ts
@@ -1,0 +1,264 @@
+import { AtpAgent, RichText } from '@atproto/api';
+import { postOperation } from './postOperations'; // Assuming postOperations.ts is in the same directory
+import ogs from 'open-graph-scraper';
+
+// Mock AtpAgent and RichText
+jest.mock('@atproto/api', () => {
+	const actualApi = jest.requireActual('@atproto/api');
+	return {
+		...actualApi,
+		AtpAgent: jest.fn().mockImplementation(() => ({
+			post: jest.fn().mockResolvedValue({ uri: 'at://did:plc:test/app.bsky.feed.post/123', cid: 'bafy...' }),
+			uploadBlob: jest.fn().mockResolvedValue({ data: { blob: { $type: 'blob', ref: 'test-blob-ref', mimeType: 'image/png', size: 100 } } }),
+		})),
+		RichText: jest.fn().mockImplementation(({ text }) => ({
+			text: text,
+			facets: [], // Default mock, can be overridden in tests
+			detectFacets: jest.fn().mockResolvedValue(undefined),
+		})),
+	};
+});
+
+// Mock open-graph-scraper
+jest.mock('open-graph-scraper', () => jest.fn());
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+describe('postOperation', () => {
+	let agent: AtpAgent;
+	let consoleWarnSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		agent = new AtpAgent(); // Creates a mocked instance due to jest.mock above
+		consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); // Suppress console.warn during tests
+	});
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore();
+	});
+
+	const defaultPostText = 'This is a test post.';
+	const defaultLangs = ['en'];
+	const defaultWebsiteCardUri = 'https://example.com';
+
+	// Scenario 1: Card Fetch Success
+	it('should include embed object when card fetch is successful', async () => {
+		const mockOgsData = {
+			error: false,
+			result: {
+				success: true,
+				ogTitle: 'Test Title',
+				ogDescription: 'Test Description',
+				ogImage: [{ url: 'https://example.com/image.png' }],
+			},
+		};
+		(ogs as jest.Mock).mockResolvedValue(mockOgsData);
+		(global.fetch as jest.Mock).mockResolvedValue({
+			ok: true,
+			arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)), // Mock image data
+		});
+
+		const websiteCardDetails = {
+			uri: defaultWebsiteCardUri,
+			title: 'Initial Title', // This should be overridden by OGS
+			description: 'Initial Description', // Overridden by OGS
+			thumbnailBinary: undefined,
+			fetchOpenGraphTags: true,
+			fallbackToLinkFacetOnError: false,
+		};
+
+		const result = await postOperation(agent, defaultPostText, defaultLangs, websiteCardDetails);
+
+		expect(ogs).toHaveBeenCalledWith({ url: defaultWebsiteCardUri });
+		expect(global.fetch).toHaveBeenCalledWith(mockOgsData.result.ogImage[0].url);
+		expect(agent.uploadBlob).toHaveBeenCalledTimes(1); // For the thumbnail
+		expect(agent.post).toHaveBeenCalledTimes(1);
+
+		const postCallArg = (agent.post as jest.Mock).mock.calls[0][0];
+		expect(postCallArg.embed).toBeDefined();
+		expect(postCallArg.embed.$type).toBe('app.bsky.embed.external');
+		expect(postCallArg.embed.external.uri).toBe(defaultWebsiteCardUri);
+		expect(postCallArg.embed.external.title).toBe(mockOgsData.result.ogTitle);
+		expect(postCallArg.embed.external.description).toBe(mockOgsData.result.ogDescription);
+		expect(postCallArg.embed.external.thumb).toBeDefined();
+
+		expect(result[0].json.uri).toBeDefined();
+		expect(result[0].json.cid).toBeDefined();
+	});
+
+	// Scenario 2: Card Fetch Failure (OGS Error) - Fallback Enabled
+	it('should not include embed and not throw when card fetch fails (OGS error) and fallback is enabled', async () => {
+		(ogs as jest.Mock).mockResolvedValue({ error: true, result: { success: false } }); // Simulate OGS error
+
+		const websiteCardDetails = {
+			uri: defaultWebsiteCardUri,
+			title: 'Test Title',
+			description: 'Test Description',
+			thumbnailBinary: undefined,
+			fetchOpenGraphTags: true,
+			fallbackToLinkFacetOnError: true, // Fallback ENABLED
+		};
+
+		const result = await postOperation(agent, defaultPostText, defaultLangs, websiteCardDetails);
+
+		expect(ogs).toHaveBeenCalledWith({ url: defaultWebsiteCardUri });
+		expect(global.fetch).not.toHaveBeenCalled(); // Should not attempt to fetch image if OGS fails
+		expect(agent.uploadBlob).not.toHaveBeenCalled(); // No thumbnail to upload
+
+		expect(agent.post).toHaveBeenCalledTimes(1);
+		const postCallArg = (agent.post as jest.Mock).mock.calls[0][0];
+		expect(postCallArg.embed).toBeUndefined(); // Embed should NOT be present
+
+		expect(result[0].json.uri).toBeDefined(); // Post should still succeed
+		expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(`Website card creation for "${defaultWebsiteCardUri}" failed`));
+	});
+
+	// Scenario 3: Card Fetch Failure (OGS Error) - Fallback Disabled
+	it('should throw error when card fetch fails (OGS error) and fallback is disabled', async () => {
+		const ogsErrorMessage = 'OGS failed spectacularly';
+		(ogs as jest.Mock).mockResolvedValue({ error: true, result: { success: false, ogTitle: ogsErrorMessage } }); // Simulate OGS error
+
+		const websiteCardDetails = {
+			uri: defaultWebsiteCardUri,
+			title: 'Test Title',
+			description: 'Test Description',
+			thumbnailBinary: undefined,
+			fetchOpenGraphTags: true,
+			fallbackToLinkFacetOnError: false, // Fallback DISABLED
+		};
+
+		await expect(
+			postOperation(agent, defaultPostText, defaultLangs, websiteCardDetails)
+		).rejects.toThrow(`Failed to create website card for "${defaultWebsiteCardUri}": Error fetching Open Graph tags: ${ogsErrorMessage}`);
+
+		expect(ogs).toHaveBeenCalledWith({ url: defaultWebsiteCardUri });
+		expect(global.fetch).not.toHaveBeenCalled();
+		expect(agent.uploadBlob).not.toHaveBeenCalled();
+		expect(agent.post).not.toHaveBeenCalled(); // Post should NOT be attempted
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+	// Scenario 4: Card Fetch Failure (Image Fetch Error) - Fallback Enabled
+	it('should not include embed and not throw when image fetch fails and fallback is enabled', async () => {
+		const mockOgsData = {
+			error: false,
+			result: {
+				success: true,
+				ogTitle: 'Test Title',
+				ogDescription: 'Test Description',
+				ogImage: [{ url: 'https://example.com/image.png' }],
+			},
+		};
+		(ogs as jest.Mock).mockResolvedValue(mockOgsData);
+		(global.fetch as jest.Mock).mockResolvedValue({ // Simulate image fetch failure
+			ok: false,
+			statusText: 'Not Found',
+		});
+
+		const websiteCardDetails = {
+			uri: defaultWebsiteCardUri,
+			title: 'Initial Title',
+			description: 'Initial Description',
+			thumbnailBinary: undefined,
+			fetchOpenGraphTags: true,
+			fallbackToLinkFacetOnError: true, // Fallback ENABLED
+		};
+
+		const result = await postOperation(agent, defaultPostText, defaultLangs, websiteCardDetails);
+
+		expect(ogs).toHaveBeenCalledWith({ url: defaultWebsiteCardUri });
+		expect(global.fetch).toHaveBeenCalledWith(mockOgsData.result.ogImage[0].url);
+		expect(agent.uploadBlob).not.toHaveBeenCalled(); // Should not upload if fetch fails
+
+		expect(agent.post).toHaveBeenCalledTimes(1);
+		const postCallArg = (agent.post as jest.Mock).mock.calls[0][0];
+		expect(postCallArg.embed).toBeUndefined(); // Embed should NOT be present
+
+		expect(result[0].json.uri).toBeDefined(); // Post should still succeed
+		expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(`Website card creation for "${defaultWebsiteCardUri}" failed: Error fetching image data from ${mockOgsData.result.ogImage[0].url}: Not Found`));
+	});
+
+	// Scenario 5: Card Fetch Failure (Image Fetch Error) - Fallback Disabled
+	it('should throw error when image fetch fails and fallback is disabled', async () => {
+		const mockOgsData = {
+			error: false,
+			result: {
+				success: true,
+				ogTitle: 'Test Title',
+				ogDescription: 'Test Description',
+				ogImage: [{ url: 'https://example.com/image.png' }],
+			},
+		};
+		(ogs as jest.Mock).mockResolvedValue(mockOgsData);
+		const fetchErrorStatusText = 'Forbidden';
+		(global.fetch as jest.Mock).mockResolvedValue({ // Simulate image fetch failure
+			ok: false,
+			statusText: fetchErrorStatusText,
+		});
+
+		const websiteCardDetails = {
+			uri: defaultWebsiteCardUri,
+			title: 'Initial Title',
+			description: 'Initial Description',
+			thumbnailBinary: undefined,
+			fetchOpenGraphTags: true,
+			fallbackToLinkFacetOnError: false, // Fallback DISABLED
+		};
+
+		await expect(
+			postOperation(agent, defaultPostText, defaultLangs, websiteCardDetails)
+		).rejects.toThrow(`Failed to create website card for "${defaultWebsiteCardUri}": Error fetching image data from ${mockOgsData.result.ogImage[0].url}: ${fetchErrorStatusText}`);
+
+		expect(ogs).toHaveBeenCalledWith({ url: defaultWebsiteCardUri });
+		expect(global.fetch).toHaveBeenCalledWith(mockOgsData.result.ogImage[0].url);
+		expect(agent.uploadBlob).not.toHaveBeenCalled();
+		expect(agent.post).not.toHaveBeenCalled();
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+	// Scenario 6: No Website Card URI Provided
+	it('should not attempt card processing if no website card URI is provided (undefined URI)', async () => {
+		const websiteCardDetails = {
+			uri: undefined, // URI is undefined
+			title: 'Test Title',
+			description: 'Test Description',
+			thumbnailBinary: undefined,
+			fetchOpenGraphTags: true,
+			fallbackToLinkFacetOnError: false,
+		};
+
+		// @ts-expect-error testing undefined uri which is not allowed by type but possible from user
+		const result = await postOperation(agent, defaultPostText, defaultLangs, websiteCardDetails);
+
+		expect(ogs).not.toHaveBeenCalled();
+		expect(global.fetch).not.toHaveBeenCalled();
+		expect(agent.uploadBlob).not.toHaveBeenCalled(); // No card processing implies no blob upload for card
+
+		expect(agent.post).toHaveBeenCalledTimes(1);
+		const postCallArg = (agent.post as jest.Mock).mock.calls[0][0];
+		expect(postCallArg.embed).toBeUndefined(); // No embed expected
+
+		expect(result[0].json.uri).toBeDefined();
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+	it('should not attempt card processing if websiteCard object itself is undefined', async () => {
+		const result = await postOperation(agent, defaultPostText, defaultLangs, undefined); // websiteCard is undefined
+
+		expect(ogs).not.toHaveBeenCalled();
+		expect(global.fetch).not.toHaveBeenCalled();
+		expect(agent.uploadBlob).not.toHaveBeenCalled();
+
+		expect(agent.post).toHaveBeenCalledTimes(1);
+		const postCallArg = (agent.post as jest.Mock).mock.calls[0][0];
+		expect(postCallArg.embed).toBeUndefined();
+
+		expect(result[0].json.uri).toBeDefined();
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+});


### PR DESCRIPTION
I've implemented two key improvements to the Bluesky v2 node:

1.  **Enhanced Error Handling:**
    - Operations within the node's `execute` method are now wrapped in item-level try-catch blocks.
    - I now use `NodeOperationError` to provide richer error details to the n8n UI.
    - I now respect the "Continue on Fail" setting: if enabled, errors are logged for the specific item, and I continue processing other items; otherwise, the error is thrown.
    - I've added unit tests to cover various error scenarios and the "Continue on Fail" behavior.

2.  **Website Card Fetch Fallback:**
    - I've added a new boolean option `fallbackToLinkFacetOnError` (default: false) to the 'Create a Post' operation when a Website Card URI is provided.
    - If card fetching (Open Graph data or thumbnail image) fails:
        - If `fallbackToLinkFacetOnError` is true, the post will be created without the embed card, and a warning is logged. The link itself will still be present if it was part of the main post text and detected as a facet.
        - If `fallbackToLinkFacetOnError` is false, the operation will fail as before, providing an error message.
    - This allows you to prioritize publishing a post over including a potentially problematic website card.
    - I've added unit tests to cover successful card creation, failures with fallback enabled/disabled, and different error sources during card fetching.