### PR TITLE
Add Bluesky Drafts API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ Feed responses are normalized and include post metadata such as author details, 
 - Update Seen Notifications
 - Get Post Interactions
 
+### Draft
+
+- Create Draft
+- Update Draft
+- Get Drafts
+- Publish Draft
+- Delete Draft
+
+Draft create/update supports:
+
+- post text and language tags
+- external URI embeds
+- quote embeds via quote post URI + CID
+
+Draft behavior:
+
+- a draft can only use one embed type (external URI or quote embed)
+- Publish Draft publishes a single draft post or full draft thread, then attempts to delete the draft
+- Publish Draft output includes `uri`, `cid`, `draftId`, and `draftDeleted` for each published post
+- image draft embeds are not supported in this node because Bluesky draft image refs are device-local paths
+
 ### Graph
 
 - Mute Thread

--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ Feed responses are normalized and include post metadata such as author details, 
 
 Draft create/update supports:
 
-- post text and language tags
-- external URI embeds
-- quote embeds via quote post URI + CID
+- Post text and language tags
+- External URI embeds
+- Quote embeds via quote post URI + CID
 
 Draft behavior:
 
-- a draft can only use one embed type (external URI or quote embed)
+- A draft can only use one embed type (external URI or quote embed)
 - Publish Draft publishes a single draft post or full draft thread, then attempts to delete the draft
 - Publish Draft output includes `uri`, `cid`, `draftId`, and `draftDeleted` for each published post
-- image draft embeds are not supported in this node because Bluesky draft image refs are device-local paths
+- Image draft embeds are not supported in this node because Bluesky draft image refs are device-local paths
 
 ### Graph
 

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -54,11 +54,11 @@ import {
 } from './listOperations';
 import { searchPostsOperation, searchProperties, searchUsersOperation } from './searchOperations';
 import {
-	createSimpleDraftPayload,
 	createDraftOperation,
 	deleteDraftOperation,
 	draftProperties,
 	getDraftsOperation,
+	publishDraftOperation,
 	updateDraftOperation,
 } from './draftOperations';
 
@@ -591,12 +591,15 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'createDraft': {
-						const draftPayload = createSimpleDraftPayload(
-							this.getNodeParameter('postText', i, '') as string,
-							this.getNodeParameter('langs', i, ['en']) as string[],
-						);
 						returnData.push(
-							...(await createDraftOperation(agent, draftPayload)),
+							...(await createDraftOperation(
+								agent,
+								this.getNodeParameter('postText', i, '') as string,
+								this.getNodeParameter('langs', i, ['en']) as string[],
+								(this.getNodeParameter('draftExternalUri', i, '') as string) || undefined,
+								(this.getNodeParameter('draftQuoteUri', i, '') as string) || undefined,
+								(this.getNodeParameter('draftQuoteCid', i, '') as string) || undefined,
+							)),
 						);
 						break;
 					}
@@ -614,15 +617,25 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'updateDraft': {
-						const draftPayload = createSimpleDraftPayload(
-							this.getNodeParameter('postText', i, '') as string,
-							this.getNodeParameter('langs', i, ['en']) as string[],
-						);
 						returnData.push(
 							...(await updateDraftOperation(
 								agent,
 								this.getNodeParameter('draftId', i) as string,
-								draftPayload,
+								this.getNodeParameter('postText', i, '') as string,
+								this.getNodeParameter('langs', i, ['en']) as string[],
+								(this.getNodeParameter('draftExternalUri', i, '') as string) || undefined,
+								(this.getNodeParameter('draftQuoteUri', i, '') as string) || undefined,
+								(this.getNodeParameter('draftQuoteCid', i, '') as string) || undefined,
+							)),
+						);
+						break;
+					}
+
+					case 'publishDraft': {
+						returnData.push(
+							...(await publishDraftOperation(
+								agent,
+								this.getNodeParameter('draftId', i) as string,
 							)),
 						);
 						break;

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -54,11 +54,10 @@ import {
 } from './listOperations';
 import { searchPostsOperation, searchProperties, searchUsersOperation } from './searchOperations';
 import {
+	createSimpleDraftPayload,
 	createDraftOperation,
 	deleteDraftOperation,
-	DraftPayloadInputMode,
 	draftProperties,
-	getDraftPayloadFromInput,
 	getDraftsOperation,
 	updateDraftOperation,
 } from './draftOperations';
@@ -592,16 +591,9 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'createDraft': {
-						const draftMode = this.getNodeParameter(
-							'draftInputMode',
-							i,
-							'simple',
-						) as DraftPayloadInputMode;
-						const draftPayload = getDraftPayloadFromInput(
-							draftMode,
-							this.getNodeParameter('draftPostText', i, '') as string,
-							this.getNodeParameter('draftLangs', i, ['en']) as string[],
-							this.getNodeParameter('draftPayload', i, '') as string,
+						const draftPayload = createSimpleDraftPayload(
+							this.getNodeParameter('postText', i, '') as string,
+							this.getNodeParameter('langs', i, ['en']) as string[],
 						);
 						returnData.push(
 							...(await createDraftOperation(agent, draftPayload)),
@@ -622,16 +614,9 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'updateDraft': {
-						const draftMode = this.getNodeParameter(
-							'draftInputMode',
-							i,
-							'simple',
-						) as DraftPayloadInputMode;
-						const draftPayload = getDraftPayloadFromInput(
-							draftMode,
-							this.getNodeParameter('draftPostText', i, '') as string,
-							this.getNodeParameter('draftLangs', i, ['en']) as string[],
-							this.getNodeParameter('draftPayload', i, '') as string,
+						const draftPayload = createSimpleDraftPayload(
+							this.getNodeParameter('postText', i, '') as string,
+							this.getNodeParameter('langs', i, ['en']) as string[],
 						);
 						returnData.push(
 							...(await updateDraftOperation(

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -56,6 +56,7 @@ import { searchPostsOperation, searchProperties, searchUsersOperation } from './
 import {
 	createDraftOperation,
 	deleteDraftOperation,
+	DraftPayloadInputMode,
 	draftProperties,
 	getDraftPayloadFromInput,
 	getDraftsOperation,
@@ -591,9 +592,11 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'createDraft': {
-						const draftMode = this.getNodeParameter('draftInputMode', i, 'simple') as
-							| 'simple'
-							| 'payload';
+						const draftMode = this.getNodeParameter(
+							'draftInputMode',
+							i,
+							'simple',
+						) as DraftPayloadInputMode;
 						const draftPayload = getDraftPayloadFromInput(
 							draftMode,
 							this.getNodeParameter('draftPostText', i, '') as string,
@@ -619,9 +622,11 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'updateDraft': {
-						const draftMode = this.getNodeParameter('draftInputMode', i, 'simple') as
-							| 'simple'
-							| 'payload';
+						const draftMode = this.getNodeParameter(
+							'draftInputMode',
+							i,
+							'simple',
+						) as DraftPayloadInputMode;
 						const draftPayload = getDraftPayloadFromInput(
 							draftMode,
 							this.getNodeParameter('draftPostText', i, '') as string,

--- a/nodes/Bluesky/V2/BlueskyV2.node.ts
+++ b/nodes/Bluesky/V2/BlueskyV2.node.ts
@@ -57,6 +57,7 @@ import {
 	createDraftOperation,
 	deleteDraftOperation,
 	draftProperties,
+	getDraftPayloadFromInput,
 	getDraftsOperation,
 	updateDraftOperation,
 } from './draftOperations';
@@ -590,12 +591,17 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'createDraft': {
+						const draftMode = this.getNodeParameter('draftInputMode', i, 'simple') as
+							| 'simple'
+							| 'payload';
+						const draftPayload = getDraftPayloadFromInput(
+							draftMode,
+							this.getNodeParameter('draftPostText', i, '') as string,
+							this.getNodeParameter('draftLangs', i, ['en']) as string[],
+							this.getNodeParameter('draftPayload', i, '') as string,
+						);
 						returnData.push(
-							...(await createDraftOperation(
-								agent,
-								this.getNodeParameter('draftPostText', i) as string,
-								this.getNodeParameter('draftLangs', i) as string[],
-							)),
+							...(await createDraftOperation(agent, draftPayload)),
 						);
 						break;
 					}
@@ -613,12 +619,20 @@ export class BlueskyV2 implements INodeType {
 					}
 
 					case 'updateDraft': {
+						const draftMode = this.getNodeParameter('draftInputMode', i, 'simple') as
+							| 'simple'
+							| 'payload';
+						const draftPayload = getDraftPayloadFromInput(
+							draftMode,
+							this.getNodeParameter('draftPostText', i, '') as string,
+							this.getNodeParameter('draftLangs', i, ['en']) as string[],
+							this.getNodeParameter('draftPayload', i, '') as string,
+						);
 						returnData.push(
 							...(await updateDraftOperation(
 								agent,
 								this.getNodeParameter('draftId', i) as string,
-								this.getNodeParameter('draftPostText', i) as string,
-								this.getNodeParameter('draftLangs', i) as string[],
+								draftPayload,
 							)),
 						);
 						break;

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -1,8 +1,8 @@
 import {
-	createSimpleDraftPayload,
 	createDraftOperation,
 	deleteDraftOperation,
 	getDraftsOperation,
+	publishDraftOperation,
 	updateDraftOperation,
 } from '../draftOperations';
 import { AtpAgent } from '@atproto/api';
@@ -12,6 +12,7 @@ describe('draftOperations', () => {
 	let getDrafts: jest.Mock;
 	let updateDraft: jest.Mock;
 	let deleteDraft: jest.Mock;
+	let post: jest.Mock;
 	let agent: AtpAgent;
 
 	beforeEach(() => {
@@ -19,6 +20,7 @@ describe('draftOperations', () => {
 		getDrafts = jest.fn();
 		updateDraft = jest.fn();
 		deleteDraft = jest.fn();
+		post = jest.fn().mockResolvedValue({ uri: 'at://test/post/1', cid: 'cid-1' });
 
 		agent = {
 			app: {
@@ -26,30 +28,58 @@ describe('draftOperations', () => {
 					draft: { createDraft, getDrafts, updateDraft, deleteDraft },
 				},
 			},
+			post,
 		} as unknown as AtpAgent;
 	});
 
-	describe('createSimpleDraftPayload', () => {
-		it('should create a draft payload from post-like inputs', () => {
-			expect(createSimpleDraftPayload('Draft text', ['en'])).toEqual({
-				$type: 'app.bsky.draft.defs#draft',
-				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Draft text' }],
-				langs: ['en'],
-			});
-		});
-	});
-
 	describe('createDraftOperation', () => {
-		it('should create a draft and return its id', async () => {
+		it('should create a draft with text and langs and return its id', async () => {
 			createDraft.mockResolvedValue({ data: { id: 'draft-id-1' } });
 
-			const draft = createSimpleDraftPayload('Hello draft', ['en']);
-			const result = await createDraftOperation(agent, draft);
+			const result = await createDraftOperation(agent, 'Hello draft', ['en']);
 
 			expect(createDraft).toHaveBeenCalledWith({
-				draft,
+				draft: {
+					$type: 'app.bsky.draft.defs#draft',
+					posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Hello draft' }],
+					langs: ['en'],
+				},
 			});
 			expect(result).toEqual([{ json: { id: 'draft-id-1' } }]);
+		});
+
+		it('should include an external embed when externalUri is provided', async () => {
+			createDraft.mockResolvedValue({ data: { id: 'draft-id-2' } });
+
+			await createDraftOperation(agent, 'Link post', ['en'], 'https://example.com');
+
+			const draftArg = createDraft.mock.calls[0][0].draft;
+			expect(draftArg.posts[0].embedExternals).toEqual([
+				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com' },
+			]);
+		});
+
+		it('should include a record embed when quoteUri and quoteCid are provided', async () => {
+			createDraft.mockResolvedValue({ data: { id: 'draft-id-3' } });
+
+			await createDraftOperation(agent, 'Quote post', ['en'], undefined, 'at://post/1', 'cid-abc');
+
+			const draftArg = createDraft.mock.calls[0][0].draft;
+			expect(draftArg.posts[0].embedRecords).toEqual([
+				{
+					$type: 'app.bsky.draft.defs#draftEmbedRecord',
+					record: { uri: 'at://post/1', cid: 'cid-abc' },
+				},
+			]);
+		});
+
+		it('should not include a record embed when only quoteUri is provided', async () => {
+			createDraft.mockResolvedValue({ data: { id: 'draft-id-4' } });
+
+			await createDraftOperation(agent, 'Incomplete quote', ['en'], undefined, 'at://post/1');
+
+			const draftArg = createDraft.mock.calls[0][0].draft;
+			expect(draftArg.posts[0].embedRecords).toBeUndefined();
 		});
 	});
 
@@ -88,20 +118,40 @@ describe('draftOperations', () => {
 	});
 
 	describe('updateDraftOperation', () => {
-		it('should update a draft and return confirmation', async () => {
+		it('should update a draft with new text and langs and return confirmation', async () => {
 			updateDraft.mockResolvedValue({});
-			const draft = createSimpleDraftPayload('Updated text', ['de']);
 
-			const result = await updateDraftOperation(agent, 'draft-id-1', draft);
+			const result = await updateDraftOperation(agent, 'draft-id-1', 'Updated text', ['de']);
 
 			expect(updateDraft).toHaveBeenCalledWith({
 				draft: {
 					$type: 'app.bsky.draft.defs#draftWithId',
 					id: 'draft-id-1',
-					draft,
+					draft: {
+						$type: 'app.bsky.draft.defs#draft',
+						posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Updated text' }],
+						langs: ['de'],
+					},
 				},
 			});
 			expect(result).toEqual([{ json: { id: 'draft-id-1', updated: true } }]);
+		});
+
+		it('should include an external embed when externalUri is provided', async () => {
+			updateDraft.mockResolvedValue({});
+
+			await updateDraftOperation(
+				agent,
+				'draft-id-1',
+				'Updated with link',
+				['en'],
+				'https://example.com',
+			);
+
+			const draftArg = updateDraft.mock.calls[0][0].draft.draft;
+			expect(draftArg.posts[0].embedExternals).toEqual([
+				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com' },
+			]);
 		});
 	});
 
@@ -116,4 +166,128 @@ describe('draftOperations', () => {
 		});
 	});
 
+	describe('publishDraftOperation', () => {
+		it('should publish the draft as a post and delete it', async () => {
+			const mockDraftView = {
+				id: 'draft-id-1',
+				draft: {
+					posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Published text' }],
+					langs: ['en'],
+				},
+				createdAt: '2025-01-01T00:00:00Z',
+				updatedAt: '2025-01-02T00:00:00Z',
+			};
+			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+
+			const result = await publishDraftOperation(agent, 'draft-id-1');
+
+			expect(post).toHaveBeenCalledWith(
+				expect.objectContaining({
+					text: 'Published text',
+					langs: ['en'],
+				}),
+			);
+			expect(deleteDraft).toHaveBeenCalledWith({ id: 'draft-id-1' });
+			expect(result).toEqual([
+				{ json: { uri: 'at://test/post/1', cid: 'cid-1', draftId: 'draft-id-1' } },
+			]);
+		});
+
+		it('should include an external embed when the draft has an external URI', async () => {
+			const mockDraftView = {
+				id: 'draft-id-2',
+				draft: {
+					posts: [
+						{
+							$type: 'app.bsky.draft.defs#draftPost',
+							text: 'Link post',
+							embedExternals: [
+								{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com' },
+							],
+						},
+					],
+					langs: ['en'],
+				},
+				createdAt: '2025-01-01T00:00:00Z',
+				updatedAt: '2025-01-02T00:00:00Z',
+			};
+			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+
+			await publishDraftOperation(agent, 'draft-id-2');
+
+			expect(post).toHaveBeenCalledWith(
+				expect.objectContaining({
+					embed: {
+						$type: 'app.bsky.embed.external',
+						external: { uri: 'https://example.com', title: '', description: '' },
+					},
+				}),
+			);
+		});
+
+		it('should include a record embed when the draft quotes a post', async () => {
+			const mockDraftView = {
+				id: 'draft-id-3',
+				draft: {
+					posts: [
+						{
+							$type: 'app.bsky.draft.defs#draftPost',
+							text: 'Quote post',
+							embedRecords: [
+								{
+									$type: 'app.bsky.draft.defs#draftEmbedRecord',
+									record: { uri: 'at://quoted/post/1', cid: 'quoted-cid' },
+								},
+							],
+						},
+					],
+					langs: ['en'],
+				},
+				createdAt: '2025-01-01T00:00:00Z',
+				updatedAt: '2025-01-02T00:00:00Z',
+			};
+			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+
+			await publishDraftOperation(agent, 'draft-id-3');
+
+			expect(post).toHaveBeenCalledWith(
+				expect.objectContaining({
+					embed: {
+						$type: 'app.bsky.embed.record',
+						record: { uri: 'at://quoted/post/1', cid: 'quoted-cid' },
+					},
+				}),
+			);
+		});
+
+		it('should throw an error when the draft is not found', async () => {
+			getDrafts.mockResolvedValue({ data: { drafts: [] } });
+
+			await expect(publishDraftOperation(agent, 'nonexistent-id')).rejects.toThrow(
+				"Draft with ID 'nonexistent-id' not found.",
+			);
+		});
+
+		it('should paginate to find the draft when it is not on the first page', async () => {
+			const mockDraftView = {
+				id: 'draft-id-page2',
+				draft: {
+					posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Found on page 2' }],
+					langs: ['en'],
+				},
+				createdAt: '2025-01-01T00:00:00Z',
+				updatedAt: '2025-01-02T00:00:00Z',
+			};
+			getDrafts
+				.mockResolvedValueOnce({ data: { drafts: [], cursor: 'next-page-cursor' } })
+				.mockResolvedValueOnce({ data: { drafts: [mockDraftView] } });
+
+			const result = await publishDraftOperation(agent, 'draft-id-page2');
+
+			expect(getDrafts).toHaveBeenCalledTimes(2);
+			expect(getDrafts).toHaveBeenNthCalledWith(1, { limit: 100 });
+			expect(getDrafts).toHaveBeenNthCalledWith(2, { limit: 100, cursor: 'next-page-cursor' });
+			expect(result[0].json.draftId).toBe('draft-id-page2');
+		});
+	});
 });

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -55,7 +55,7 @@ describe('draftOperations', () => {
 
 			const draftArg = createDraft.mock.calls[0][0].draft;
 			expect(draftArg.posts[0].embedExternals).toEqual([
-				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com' },
+				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com/' },
 			]);
 			expect(draftArg.posts[0].embedRecords).toBeUndefined();
 		});
@@ -200,7 +200,7 @@ describe('draftOperations', () => {
 
 			const draftArg = updateDraft.mock.calls[0][0].draft.draft;
 			expect(draftArg.posts[0].embedExternals).toEqual([
-				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com' },
+				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com/' },
 			]);
 		});
 	});

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -127,7 +127,46 @@ describe('draftOperations', () => {
 		});
 
 		it('should throw for invalid JSON payloads', () => {
-			expect(() => parseDraftPayload('{invalid-json')).toThrow('Draft payload must be valid JSON');
+			expect(() => parseDraftPayload('{invalid-json')).toThrow(
+				'Draft payload must be valid JSON:',
+			);
+		});
+
+		it('should throw when payload is not a JSON object', () => {
+			expect(() => parseDraftPayload('null')).toThrow('Draft payload must be a JSON object');
+			expect(() => parseDraftPayload('[]')).toThrow('Draft payload must be a JSON object');
+		});
+
+		it('should throw when posts are missing, invalid, or empty', () => {
+			expect(() => parseDraftPayload(JSON.stringify({ langs: ['en'] }))).toThrow(
+				'Draft payload must include "posts"',
+			);
+			expect(() => parseDraftPayload(JSON.stringify({ posts: {} }))).toThrow(
+				'Draft payload "posts" must be an array',
+			);
+			expect(() => parseDraftPayload(JSON.stringify({ posts: [] }))).toThrow(
+				'Draft payload "posts" must not be empty',
+			);
+		});
+
+		it('should throw when a draft post has no valid text field', () => {
+			expect(() =>
+				parseDraftPayload(
+					JSON.stringify({
+						posts: [{}],
+					}),
+				),
+			).toThrow('Each draft post must include a "text" string');
+		});
+
+		it('should throw when a draft post is not an object', () => {
+			expect(() =>
+				parseDraftPayload(
+					JSON.stringify({
+						posts: ['invalid'],
+					}),
+				),
+			).toThrow('Each draft post must be a JSON object');
 		});
 	});
 
@@ -148,6 +187,22 @@ describe('draftOperations', () => {
 				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Advanced draft' }],
 				langs: ['de'],
 			});
+		});
+
+		it('should use simple mode for text and language input', () => {
+			const payload = getDraftPayloadFromInput('simple', 'Simple draft', ['it']);
+
+			expect(payload).toEqual({
+				$type: 'app.bsky.draft.defs#draft',
+				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Simple draft' }],
+				langs: ['it'],
+			});
+		});
+
+		it('should fail when payload mode is selected without payload JSON', () => {
+			expect(() => getDraftPayloadFromInput('payload', 'Ignored text', ['en'], '   ')).toThrow(
+				'Draft payload is required when using payload mode',
+			);
 		});
 	});
 });

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -75,13 +75,18 @@ describe('draftOperations', () => {
 			expect(draftArg.posts[0].embedExternals).toBeUndefined();
 		});
 
-		it('should not include a record embed when only quoteUri is provided', async () => {
-			createDraft.mockResolvedValue({ data: { id: 'draft-id-4' } });
+		it('should throw when only quoteUri is provided', async () => {
+			await expect(
+				createDraftOperation(agent, 'Incomplete quote', ['en'], undefined, 'at://post/1'),
+			).rejects.toThrow('Quote Post URI and Quote Post CID must be provided together.');
+			expect(createDraft).not.toHaveBeenCalled();
+		});
 
-			await createDraftOperation(agent, 'Incomplete quote', ['en'], undefined, 'at://post/1');
-
-			const draftArg = createDraft.mock.calls[0][0].draft;
-			expect(draftArg.posts[0].embedRecords).toBeUndefined();
+		it('should throw when only quoteCid is provided', async () => {
+			await expect(
+				createDraftOperation(agent, 'Incomplete quote', ['en'], undefined, undefined, 'cid-abc'),
+			).rejects.toThrow('Quote Post URI and Quote Post CID must be provided together.');
+			expect(createDraft).not.toHaveBeenCalled();
 		});
 
 		it('should throw when both externalUri and quoteUri/quoteCid are provided', async () => {
@@ -109,9 +114,21 @@ describe('draftOperations', () => {
 					'https://example.com',
 					'at://post/1',
 				),
-			).rejects.toThrow(
-				'A draft post can only have one embed type. Provide either an External URI or a Quote Post URI/CID, not both.',
+			).rejects.toThrow('Quote Post URI and Quote Post CID must be provided together.');
+			expect(createDraft).not.toHaveBeenCalled();
+		});
+
+		it('should throw when externalUri is invalid', async () => {
+			await expect(createDraftOperation(agent, 'Link post', ['en'], 'not-a-url')).rejects.toThrow(
+				'External URI must be a valid URL.',
 			);
+			expect(createDraft).not.toHaveBeenCalled();
+		});
+
+		it('should throw when externalUri uses an unsupported scheme', async () => {
+			await expect(
+				createDraftOperation(agent, 'Link post', ['en'], 'ftp://example.com'),
+			).rejects.toThrow('External URI must use the http or https scheme.');
 			expect(createDraft).not.toHaveBeenCalled();
 		});
 	});

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -1,7 +1,10 @@
 import {
+	createSimpleDraftPayload,
 	createDraftOperation,
 	deleteDraftOperation,
+	getDraftPayloadFromInput,
 	getDraftsOperation,
+	parseDraftPayload,
 	updateDraftOperation,
 } from '../draftOperations';
 import { AtpAgent } from '@atproto/api';
@@ -32,14 +35,11 @@ describe('draftOperations', () => {
 		it('should create a draft and return its id', async () => {
 			createDraft.mockResolvedValue({ data: { id: 'draft-id-1' } });
 
-			const result = await createDraftOperation(agent, 'Hello draft', ['en']);
+			const draft = createSimpleDraftPayload('Hello draft', ['en']);
+			const result = await createDraftOperation(agent, draft);
 
 			expect(createDraft).toHaveBeenCalledWith({
-				draft: {
-					$type: 'app.bsky.draft.defs#draft',
-					posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Hello draft' }],
-					langs: ['en'],
-				},
+				draft,
 			});
 			expect(result).toEqual([{ json: { id: 'draft-id-1' } }]);
 		});
@@ -82,18 +82,15 @@ describe('draftOperations', () => {
 	describe('updateDraftOperation', () => {
 		it('should update a draft and return confirmation', async () => {
 			updateDraft.mockResolvedValue({});
+			const draft = createSimpleDraftPayload('Updated text', ['de']);
 
-			const result = await updateDraftOperation(agent, 'draft-id-1', 'Updated text', ['de']);
+			const result = await updateDraftOperation(agent, 'draft-id-1', draft);
 
 			expect(updateDraft).toHaveBeenCalledWith({
 				draft: {
 					$type: 'app.bsky.draft.defs#draftWithId',
 					id: 'draft-id-1',
-					draft: {
-						$type: 'app.bsky.draft.defs#draft',
-						posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Updated text' }],
-						langs: ['de'],
-					},
+					draft,
 				},
 			});
 			expect(result).toEqual([{ json: { id: 'draft-id-1', updated: true } }]);
@@ -108,6 +105,49 @@ describe('draftOperations', () => {
 
 			expect(deleteDraft).toHaveBeenCalledWith({ id: 'draft-id-1' });
 			expect(result).toEqual([{ json: { id: 'draft-id-1', deleted: true } }]);
+		});
+	});
+
+	describe('parseDraftPayload', () => {
+		it('should parse payload and normalize missing $type values', () => {
+			const payload = parseDraftPayload(
+				JSON.stringify({
+					posts: [{ text: 'Payload text' }],
+					langs: ['en'],
+					deviceName: 'n8n',
+				}),
+			);
+
+			expect(payload).toEqual({
+				$type: 'app.bsky.draft.defs#draft',
+				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Payload text' }],
+				langs: ['en'],
+				deviceName: 'n8n',
+			});
+		});
+
+		it('should throw for invalid JSON payloads', () => {
+			expect(() => parseDraftPayload('{invalid-json')).toThrow('Draft payload must be valid JSON');
+		});
+	});
+
+	describe('getDraftPayloadFromInput', () => {
+		it('should use payload mode for advanced draft JSON', () => {
+			const payload = getDraftPayloadFromInput(
+				'payload',
+				'Ignored text',
+				['en'],
+				JSON.stringify({
+					posts: [{ text: 'Advanced draft' }],
+					langs: ['de'],
+				}),
+			);
+
+			expect(payload).toEqual({
+				$type: 'app.bsky.draft.defs#draft',
+				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Advanced draft' }],
+				langs: ['de'],
+			});
 		});
 	});
 });

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -2,9 +2,7 @@ import {
 	createSimpleDraftPayload,
 	createDraftOperation,
 	deleteDraftOperation,
-	getDraftPayloadFromInput,
 	getDraftsOperation,
-	parseDraftPayload,
 	updateDraftOperation,
 } from '../draftOperations';
 import { AtpAgent } from '@atproto/api';
@@ -29,6 +27,16 @@ describe('draftOperations', () => {
 				},
 			},
 		} as unknown as AtpAgent;
+	});
+
+	describe('createSimpleDraftPayload', () => {
+		it('should create a draft payload from post-like inputs', () => {
+			expect(createSimpleDraftPayload('Draft text', ['en'])).toEqual({
+				$type: 'app.bsky.draft.defs#draft',
+				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Draft text' }],
+				langs: ['en'],
+			});
+		});
 	});
 
 	describe('createDraftOperation', () => {
@@ -108,101 +116,4 @@ describe('draftOperations', () => {
 		});
 	});
 
-	describe('parseDraftPayload', () => {
-		it('should parse payload and normalize missing $type values', () => {
-			const payload = parseDraftPayload(
-				JSON.stringify({
-					posts: [{ text: 'Payload text' }],
-					langs: ['en'],
-					deviceName: 'n8n',
-				}),
-			);
-
-			expect(payload).toEqual({
-				$type: 'app.bsky.draft.defs#draft',
-				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Payload text' }],
-				langs: ['en'],
-				deviceName: 'n8n',
-			});
-		});
-
-		it('should throw for invalid JSON payloads', () => {
-			expect(() => parseDraftPayload('{invalid-json')).toThrow(
-				'Draft payload must be valid JSON:',
-			);
-		});
-
-		it('should throw when payload is not a JSON object', () => {
-			expect(() => parseDraftPayload('null')).toThrow('Draft payload must be a JSON object');
-			expect(() => parseDraftPayload('[]')).toThrow('Draft payload must be a JSON object');
-		});
-
-		it('should throw when posts are missing, invalid, or empty', () => {
-			expect(() => parseDraftPayload(JSON.stringify({ langs: ['en'] }))).toThrow(
-				'Draft payload must include "posts"',
-			);
-			expect(() => parseDraftPayload(JSON.stringify({ posts: {} }))).toThrow(
-				'Draft payload "posts" must be an array',
-			);
-			expect(() => parseDraftPayload(JSON.stringify({ posts: [] }))).toThrow(
-				'Draft payload "posts" must not be empty',
-			);
-		});
-
-		it('should throw when a draft post has no valid text field', () => {
-			expect(() =>
-				parseDraftPayload(
-					JSON.stringify({
-						posts: [{}],
-					}),
-				),
-			).toThrow('Each draft post must include a "text" string');
-		});
-
-		it('should throw when a draft post is not an object', () => {
-			expect(() =>
-				parseDraftPayload(
-					JSON.stringify({
-						posts: ['invalid'],
-					}),
-				),
-			).toThrow('Each draft post must be a JSON object');
-		});
-	});
-
-	describe('getDraftPayloadFromInput', () => {
-		it('should use payload mode for advanced draft JSON', () => {
-			const payload = getDraftPayloadFromInput(
-				'payload',
-				'Ignored text',
-				['en'],
-				JSON.stringify({
-					posts: [{ text: 'Advanced draft' }],
-					langs: ['de'],
-				}),
-			);
-
-			expect(payload).toEqual({
-				$type: 'app.bsky.draft.defs#draft',
-				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Advanced draft' }],
-				langs: ['de'],
-			});
-		});
-
-		it('should use simple mode for text and language input', () => {
-			const payload = getDraftPayloadFromInput('simple', 'Simple draft', ['it']);
-
-			expect(payload).toEqual({
-				$type: 'app.bsky.draft.defs#draft',
-				posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Simple draft' }],
-				langs: ['it'],
-			});
-		});
-
-		it('should fail when payload mode is selected without payload JSON', () => {
-			expect(() => getDraftPayloadFromInput('payload', 'Ignored text', ['en'], '   ')).toThrow(
-				'Draft payload is required when using payload mode',
-			);
-		});
-	});
 });

--- a/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/draftOperations.test.ts
@@ -57,6 +57,7 @@ describe('draftOperations', () => {
 			expect(draftArg.posts[0].embedExternals).toEqual([
 				{ $type: 'app.bsky.draft.defs#draftEmbedExternal', uri: 'https://example.com' },
 			]);
+			expect(draftArg.posts[0].embedRecords).toBeUndefined();
 		});
 
 		it('should include a record embed when quoteUri and quoteCid are provided', async () => {
@@ -71,6 +72,7 @@ describe('draftOperations', () => {
 					record: { uri: 'at://post/1', cid: 'cid-abc' },
 				},
 			]);
+			expect(draftArg.posts[0].embedExternals).toBeUndefined();
 		});
 
 		it('should not include a record embed when only quoteUri is provided', async () => {
@@ -80,6 +82,37 @@ describe('draftOperations', () => {
 
 			const draftArg = createDraft.mock.calls[0][0].draft;
 			expect(draftArg.posts[0].embedRecords).toBeUndefined();
+		});
+
+		it('should throw when both externalUri and quoteUri/quoteCid are provided', async () => {
+			await expect(
+				createDraftOperation(
+					agent,
+					'Ambiguous post',
+					['en'],
+					'https://example.com',
+					'at://post/1',
+					'cid-abc',
+				),
+			).rejects.toThrow(
+				'A draft post can only have one embed type. Provide either an External URI or a Quote Post URI/CID, not both.',
+			);
+			expect(createDraft).not.toHaveBeenCalled();
+		});
+
+		it('should throw when externalUri is provided alongside a partial quote (only quoteUri)', async () => {
+			await expect(
+				createDraftOperation(
+					agent,
+					'Ambiguous post',
+					['en'],
+					'https://example.com',
+					'at://post/1',
+				),
+			).rejects.toThrow(
+				'A draft post can only have one embed type. Provide either an External URI or a Quote Post URI/CID, not both.',
+			);
+			expect(createDraft).not.toHaveBeenCalled();
 		});
 	});
 
@@ -167,7 +200,7 @@ describe('draftOperations', () => {
 	});
 
 	describe('publishDraftOperation', () => {
-		it('should publish the draft as a post and delete it', async () => {
+		it('should publish the draft as a post, delete it, and return the result', async () => {
 			const mockDraftView = {
 				id: 'draft-id-1',
 				draft: {
@@ -178,9 +211,11 @@ describe('draftOperations', () => {
 				updatedAt: '2025-01-02T00:00:00Z',
 			};
 			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+			deleteDraft.mockResolvedValue({});
 
 			const result = await publishDraftOperation(agent, 'draft-id-1');
 
+			expect(post).toHaveBeenCalledTimes(1);
 			expect(post).toHaveBeenCalledWith(
 				expect.objectContaining({
 					text: 'Published text',
@@ -189,11 +224,82 @@ describe('draftOperations', () => {
 			);
 			expect(deleteDraft).toHaveBeenCalledWith({ id: 'draft-id-1' });
 			expect(result).toEqual([
-				{ json: { uri: 'at://test/post/1', cid: 'cid-1', draftId: 'draft-id-1' } },
+				{
+					json: {
+						uri: 'at://test/post/1',
+						cid: 'cid-1',
+						draftId: 'draft-id-1',
+						draftDeleted: true,
+					},
+				},
 			]);
 		});
 
-		it('should include an external embed when the draft has an external URI', async () => {
+		it('should publish all posts as a thread when the draft has multiple posts', async () => {
+			const mockDraftView = {
+				id: 'draft-id-thread',
+				draft: {
+					posts: [
+						{ $type: 'app.bsky.draft.defs#draftPost', text: 'Thread post 1' },
+						{ $type: 'app.bsky.draft.defs#draftPost', text: 'Thread post 2' },
+						{ $type: 'app.bsky.draft.defs#draftPost', text: 'Thread post 3' },
+					],
+					langs: ['en'],
+				},
+				createdAt: '2025-01-01T00:00:00Z',
+				updatedAt: '2025-01-02T00:00:00Z',
+			};
+			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+			post
+				.mockResolvedValueOnce({ uri: 'at://test/post/1', cid: 'cid-1' })
+				.mockResolvedValueOnce({ uri: 'at://test/post/2', cid: 'cid-2' })
+				.mockResolvedValueOnce({ uri: 'at://test/post/3', cid: 'cid-3' });
+			deleteDraft.mockResolvedValue({});
+
+			const result = await publishDraftOperation(agent, 'draft-id-thread');
+
+			expect(post).toHaveBeenCalledTimes(3);
+
+			// First post has no reply
+			expect(post).toHaveBeenNthCalledWith(
+				1,
+				expect.not.objectContaining({ reply: expect.anything() }),
+			);
+
+			// Second post replies to the first
+			expect(post).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					text: 'Thread post 2',
+					reply: {
+						root: { uri: 'at://test/post/1', cid: 'cid-1' },
+						parent: { uri: 'at://test/post/1', cid: 'cid-1' },
+					},
+				}),
+			);
+
+			// Third post: root is still the first, parent is the second
+			expect(post).toHaveBeenNthCalledWith(
+				3,
+				expect.objectContaining({
+					text: 'Thread post 3',
+					reply: {
+						root: { uri: 'at://test/post/1', cid: 'cid-1' },
+						parent: { uri: 'at://test/post/2', cid: 'cid-2' },
+					},
+				}),
+			);
+
+			expect(result).toHaveLength(3);
+			expect(result[0].json).toEqual(
+				expect.objectContaining({ uri: 'at://test/post/1', draftId: 'draft-id-thread' }),
+			);
+			expect(result[2].json).toEqual(
+				expect.objectContaining({ uri: 'at://test/post/3', draftId: 'draft-id-thread' }),
+			);
+		});
+
+		it('should include an external embed with URI as title when the draft has an external URI', async () => {
 			const mockDraftView = {
 				id: 'draft-id-2',
 				draft: {
@@ -212,6 +318,7 @@ describe('draftOperations', () => {
 				updatedAt: '2025-01-02T00:00:00Z',
 			};
 			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+			deleteDraft.mockResolvedValue({});
 
 			await publishDraftOperation(agent, 'draft-id-2');
 
@@ -219,7 +326,11 @@ describe('draftOperations', () => {
 				expect.objectContaining({
 					embed: {
 						$type: 'app.bsky.embed.external',
-						external: { uri: 'https://example.com', title: '', description: '' },
+						external: {
+							uri: 'https://example.com',
+							title: 'https://example.com',
+							description: '',
+						},
 					},
 				}),
 			);
@@ -247,6 +358,7 @@ describe('draftOperations', () => {
 				updatedAt: '2025-01-02T00:00:00Z',
 			};
 			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+			deleteDraft.mockResolvedValue({});
 
 			await publishDraftOperation(agent, 'draft-id-3');
 
@@ -281,6 +393,7 @@ describe('draftOperations', () => {
 			getDrafts
 				.mockResolvedValueOnce({ data: { drafts: [], cursor: 'next-page-cursor' } })
 				.mockResolvedValueOnce({ data: { drafts: [mockDraftView] } });
+			deleteDraft.mockResolvedValue({});
 
 			const result = await publishDraftOperation(agent, 'draft-id-page2');
 
@@ -288,6 +401,34 @@ describe('draftOperations', () => {
 			expect(getDrafts).toHaveBeenNthCalledWith(1, { limit: 100 });
 			expect(getDrafts).toHaveBeenNthCalledWith(2, { limit: 100, cursor: 'next-page-cursor' });
 			expect(result[0].json.draftId).toBe('draft-id-page2');
+		});
+
+		it('should return draftDeleted: false and log an error when draft deletion fails after posting', async () => {
+			const mockDraftView = {
+				id: 'draft-id-del-fail',
+				draft: {
+					posts: [{ $type: 'app.bsky.draft.defs#draftPost', text: 'Delete fail post' }],
+					langs: ['en'],
+				},
+				createdAt: '2025-01-01T00:00:00Z',
+				updatedAt: '2025-01-02T00:00:00Z',
+			};
+			getDrafts.mockResolvedValue({ data: { drafts: [mockDraftView] } });
+			deleteDraft.mockRejectedValue(new Error('Network error'));
+
+			const result = await publishDraftOperation(agent, 'draft-id-del-fail');
+
+			expect(post).toHaveBeenCalledTimes(1);
+			expect(result).toEqual([
+				expect.objectContaining({
+					json: expect.objectContaining({
+						uri: 'at://test/post/1',
+						cid: 'cid-1',
+						draftId: 'draft-id-del-fail',
+						draftDeleted: false,
+					}),
+				}),
+			]);
 		});
 	});
 });

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -166,14 +166,20 @@ function buildDraftPayload(
 	quoteUri?: string,
 	quoteCid?: string,
 ): AppBskyDraftDefs.Draft {
-	const hasQuoteEmbed = Boolean(quoteUri && quoteCid);
-	const hasPartialQuote = Boolean(quoteUri || quoteCid) && !hasQuoteEmbed;
+	const quoteRecord =
+		quoteUri && quoteCid
+			? {
+					uri: quoteUri,
+					cid: quoteCid,
+				}
+			: undefined;
+	const hasPartialQuote = Boolean(quoteUri || quoteCid) && !quoteRecord;
 
 	if (hasPartialQuote) {
 		throw new Error('Quote Post URI and Quote Post CID must be provided together.');
 	}
 
-	if (externalUri && hasQuoteEmbed) {
+	if (externalUri && quoteRecord) {
 		throw new Error(
 			'A draft post can only have one embed type. Provide either an External URI or a Quote Post URI/CID, not both.',
 		);
@@ -207,11 +213,11 @@ function buildDraftPayload(
 				uri: normalizedExternalUri,
 			},
 		];
-	} else if (hasQuoteEmbed) {
+	} else if (quoteRecord) {
 		draftPost.embedRecords = [
 			{
 				$type: 'app.bsky.draft.defs#draftEmbedRecord',
-				record: { uri: quoteUri!, cid: quoteCid! },
+				record: quoteRecord,
 			},
 		];
 	}

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -2,16 +2,6 @@ import { AppBskyDraftDefs, AtpAgent } from '@atproto/api';
 import { IDataObject, INodeExecutionData, INodeProperties } from 'n8n-workflow';
 import { getLanguageOptions } from './languages';
 
-export type DraftPayloadInputMode = 'simple' | 'payload';
-const defaultDraftPayloadJson = JSON.stringify(
-	{
-		posts: [{ text: 'Hello from draft payload' }],
-		langs: ['en'],
-	},
-	null,
-	2,
-);
-
 export const draftProperties: INodeProperties[] = [
 	{
 		displayName: 'Operation',
@@ -52,30 +42,6 @@ export const draftProperties: INodeProperties[] = [
 		default: 'createDraft',
 	},
 	{
-		displayName: 'Input Mode',
-		name: 'draftInputMode',
-		type: 'options',
-		default: 'simple',
-		options: [
-			{
-				name: 'Simple',
-				value: 'simple',
-				description: 'Use text and language fields',
-			},
-			{
-				name: 'Full Draft Payload',
-				value: 'payload',
-				description: 'Provide the complete draft payload as JSON',
-			},
-		],
-		displayOptions: {
-			show: {
-				resource: ['draft'],
-				operation: ['createDraft', 'updateDraft'],
-			},
-		},
-	},
-	{
 		displayName: 'Draft ID',
 		name: 'draftId',
 		type: 'string',
@@ -91,25 +57,19 @@ export const draftProperties: INodeProperties[] = [
 	},
 	{
 		displayName: 'Post Text',
-		name: 'draftPostText',
+		name: 'postText',
 		type: 'string',
 		default: '',
-		required: true,
-		description: 'The text content of the draft post',
-		typeOptions: {
-			rows: 4,
-		},
 		displayOptions: {
 			show: {
 				resource: ['draft'],
 				operation: ['createDraft', 'updateDraft'],
-				draftInputMode: ['simple'],
 			},
 		},
 	},
 	{
 		displayName: 'Language Names or IDs',
-		name: 'draftLangs',
+		name: 'langs',
 		type: 'multiOptions',
 		description:
 			'Choose from the list of supported languages. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
@@ -119,26 +79,6 @@ export const draftProperties: INodeProperties[] = [
 			show: {
 				resource: ['draft'],
 				operation: ['createDraft', 'updateDraft'],
-				draftInputMode: ['simple'],
-			},
-		},
-	},
-	{
-		displayName: 'Draft Payload (JSON)',
-		name: 'draftPayload',
-		type: 'string',
-		required: true,
-		default: defaultDraftPayloadJson,
-		typeOptions: {
-			rows: 10,
-		},
-		description:
-			'Full app.bsky.draft.defs#draft payload JSON, including optional labels and embeds',
-		displayOptions: {
-			show: {
-				resource: ['draft'],
-				operation: ['createDraft', 'updateDraft'],
-				draftInputMode: ['payload'],
 			},
 		},
 	},
@@ -188,71 +128,6 @@ export function createSimpleDraftPayload(
 		],
 		langs,
 	};
-}
-
-export function parseDraftPayload(rawPayload: string): AppBskyDraftDefs.Draft {
-	let parsedPayload: unknown;
-
-	try {
-		parsedPayload = JSON.parse(rawPayload);
-	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Unknown parsing error';
-		throw new Error(`Draft payload must be valid JSON: ${message}`);
-	}
-
-	if (typeof parsedPayload !== 'object' || parsedPayload === null || Array.isArray(parsedPayload)) {
-		throw new Error('Draft payload must be a JSON object');
-	}
-
-	const payload = parsedPayload as AppBskyDraftDefs.Draft;
-
-	if (payload.posts === undefined) {
-		throw new Error('Draft payload must include "posts"');
-	}
-
-	if (!Array.isArray(payload.posts)) {
-		throw new Error('Draft payload "posts" must be an array');
-	}
-
-	if (payload.posts.length === 0) {
-		throw new Error('Draft payload "posts" must not be empty');
-	}
-
-	for (const post of payload.posts) {
-		if (typeof post !== 'object' || post === null) {
-			throw new Error('Each draft post must be a JSON object');
-		}
-
-		if (typeof post.text !== 'string') {
-			throw new Error('Each draft post must include a "text" string');
-		}
-	}
-
-	return {
-		...payload,
-		$type: payload.$type ?? 'app.bsky.draft.defs#draft',
-		posts: payload.posts.map((post) => ({
-			...post,
-			$type: post.$type ?? 'app.bsky.draft.defs#draftPost',
-		})),
-	};
-}
-
-export function getDraftPayloadFromInput(
-	mode: DraftPayloadInputMode,
-	postText: string,
-	langs: string[],
-	rawPayload?: string,
-): AppBskyDraftDefs.Draft {
-	if (mode === 'payload') {
-		if (!rawPayload || !rawPayload.trim()) {
-			throw new Error('Draft payload is required when using payload mode');
-		}
-
-		return parseDraftPayload(rawPayload);
-	}
-
-	return createSimpleDraftPayload(postText, langs);
 }
 
 export async function createDraftOperation(

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -166,10 +166,33 @@ function buildDraftPayload(
 	quoteUri?: string,
 	quoteCid?: string,
 ): AppBskyDraftDefs.Draft {
-	if (externalUri && (quoteUri || quoteCid)) {
+	const hasQuoteEmbed = Boolean(quoteUri && quoteCid);
+	const hasPartialQuote = Boolean(quoteUri || quoteCid) && !hasQuoteEmbed;
+
+	if (hasPartialQuote) {
+		throw new Error('Quote Post URI and Quote Post CID must be provided together.');
+	}
+
+	if (externalUri && hasQuoteEmbed) {
 		throw new Error(
 			'A draft post can only have one embed type. Provide either an External URI or a Quote Post URI/CID, not both.',
 		);
+	}
+
+	let normalizedExternalUri: string | undefined;
+	if (externalUri) {
+		let parsedExternalUri: URL;
+		try {
+			parsedExternalUri = new URL(externalUri);
+		} catch {
+			throw new Error('External URI must be a valid URL.');
+		}
+
+		if (!['http:', 'https:'].includes(parsedExternalUri.protocol)) {
+			throw new Error('External URI must use the http or https scheme.');
+		}
+
+		normalizedExternalUri = parsedExternalUri.toString();
 	}
 
 	const draftPost: AppBskyDraftDefs.DraftPost = {
@@ -177,14 +200,14 @@ function buildDraftPayload(
 		text: postText,
 	};
 
-	if (externalUri) {
+	if (normalizedExternalUri) {
 		draftPost.embedExternals = [
 			{
 				$type: 'app.bsky.draft.defs#draftEmbedExternal',
-				uri: externalUri,
+				uri: normalizedExternalUri,
 			},
 		];
-	} else if (quoteUri && quoteCid) {
+	} else if (hasQuoteEmbed && quoteUri && quoteCid) {
 		draftPost.embedRecords = [
 			{
 				$type: 'app.bsky.draft.defs#draftEmbedRecord',

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -1,6 +1,8 @@
-import { AtpAgent } from '@atproto/api';
+import { AppBskyDraftDefs, AtpAgent } from '@atproto/api';
 import { IDataObject, INodeExecutionData, INodeProperties } from 'n8n-workflow';
 import { getLanguageOptions } from './languages';
+
+type DraftPayloadInputMode = 'simple' | 'payload';
 
 export const draftProperties: INodeProperties[] = [
 	{
@@ -42,6 +44,30 @@ export const draftProperties: INodeProperties[] = [
 		default: 'createDraft',
 	},
 	{
+		displayName: 'Input Mode',
+		name: 'draftInputMode',
+		type: 'options',
+		default: 'simple',
+		options: [
+			{
+				name: 'Simple',
+				value: 'simple',
+				description: 'Use text and language fields',
+			},
+			{
+				name: 'Full Draft Payload',
+				value: 'payload',
+				description: 'Provide the complete draft payload as JSON',
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['draft'],
+				operation: ['createDraft', 'updateDraft'],
+			},
+		},
+	},
+	{
 		displayName: 'Draft ID',
 		name: 'draftId',
 		type: 'string',
@@ -69,6 +95,7 @@ export const draftProperties: INodeProperties[] = [
 			show: {
 				resource: ['draft'],
 				operation: ['createDraft', 'updateDraft'],
+				draftInputMode: ['simple'],
 			},
 		},
 	},
@@ -84,6 +111,27 @@ export const draftProperties: INodeProperties[] = [
 			show: {
 				resource: ['draft'],
 				operation: ['createDraft', 'updateDraft'],
+				draftInputMode: ['simple'],
+			},
+		},
+	},
+	{
+		displayName: 'Draft Payload (JSON)',
+		name: 'draftPayload',
+		type: 'string',
+		required: true,
+		default:
+			'{\n  "posts": [\n    {\n      "text": "Hello from draft payload"\n    }\n  ],\n  "langs": [\n    "en"\n  ]\n}',
+		typeOptions: {
+			rows: 10,
+		},
+		description:
+			'Full app.bsky.draft.defs#draft payload JSON, including optional labels and embeds',
+		displayOptions: {
+			show: {
+				resource: ['draft'],
+				operation: ['createDraft', 'updateDraft'],
+				draftInputMode: ['payload'],
 			},
 		},
 	},
@@ -119,22 +167,76 @@ export const draftProperties: INodeProperties[] = [
 	},
 ];
 
-export async function createDraftOperation(
-	agent: AtpAgent,
+export function createSimpleDraftPayload(
 	postText: string,
 	langs: string[],
+): AppBskyDraftDefs.Draft {
+	return {
+		$type: 'app.bsky.draft.defs#draft',
+		posts: [
+			{
+				$type: 'app.bsky.draft.defs#draftPost',
+				text: postText,
+			},
+		],
+		langs,
+	};
+}
+
+export function parseDraftPayload(rawPayload: string): AppBskyDraftDefs.Draft {
+	let parsedPayload: unknown;
+
+	try {
+		parsedPayload = JSON.parse(rawPayload);
+	} catch {
+		throw new Error('Draft payload must be valid JSON');
+	}
+
+	if (!parsedPayload || typeof parsedPayload !== 'object' || Array.isArray(parsedPayload)) {
+		throw new Error('Draft payload must be a JSON object');
+	}
+
+	const payload = parsedPayload as AppBskyDraftDefs.Draft;
+
+	if (!Array.isArray(payload.posts) || payload.posts.length === 0) {
+		throw new Error('Draft payload must include a non-empty "posts" array');
+	}
+
+	for (const post of payload.posts) {
+		if (!post || typeof post !== 'object' || typeof post.text !== 'string') {
+			throw new Error('Each draft post must include a "text" string');
+		}
+	}
+
+	return {
+		...payload,
+		$type: payload.$type ?? 'app.bsky.draft.defs#draft',
+		posts: payload.posts.map((post) => ({
+			...post,
+			$type: post.$type ?? 'app.bsky.draft.defs#draftPost',
+		})),
+	};
+}
+
+export function getDraftPayloadFromInput(
+	mode: DraftPayloadInputMode,
+	postText: string,
+	langs: string[],
+	rawPayload?: string,
+): AppBskyDraftDefs.Draft {
+	if (mode === 'payload') {
+		return parseDraftPayload(rawPayload ?? '');
+	}
+
+	return createSimpleDraftPayload(postText, langs);
+}
+
+export async function createDraftOperation(
+	agent: AtpAgent,
+	draft: AppBskyDraftDefs.Draft,
 ): Promise<INodeExecutionData[]> {
 	const response = await agent.app.bsky.draft.createDraft({
-		draft: {
-			$type: 'app.bsky.draft.defs#draft',
-			posts: [
-				{
-					$type: 'app.bsky.draft.defs#draftPost',
-					text: postText,
-				},
-			],
-			langs,
-		},
+		draft,
 	});
 
 	return [{ json: { id: response.data.id } }];
@@ -160,23 +262,13 @@ export async function getDraftsOperation(
 export async function updateDraftOperation(
 	agent: AtpAgent,
 	draftId: string,
-	postText: string,
-	langs: string[],
+	draft: AppBskyDraftDefs.Draft,
 ): Promise<INodeExecutionData[]> {
 	await agent.app.bsky.draft.updateDraft({
 		draft: {
 			$type: 'app.bsky.draft.defs#draftWithId',
 			id: draftId,
-			draft: {
-				$type: 'app.bsky.draft.defs#draft',
-				posts: [
-					{
-						$type: 'app.bsky.draft.defs#draftPost',
-						text: postText,
-					},
-				],
-				langs,
-			},
+			draft,
 		},
 	});
 

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -207,7 +207,7 @@ function buildDraftPayload(
 				uri: normalizedExternalUri,
 			},
 		];
-	} else if (hasQuoteEmbed && quoteUri && quoteCid) {
+	} else if (hasQuoteEmbed) {
 		draftPost.embedRecords = [
 			{
 				$type: 'app.bsky.draft.defs#draftEmbedRecord',

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -166,6 +166,12 @@ function buildDraftPayload(
 	quoteUri?: string,
 	quoteCid?: string,
 ): AppBskyDraftDefs.Draft {
+	if (externalUri && (quoteUri || quoteCid)) {
+		throw new Error(
+			'A draft post can only have one embed type. Provide either an External URI or a Quote Post URI/CID, not both.',
+		);
+	}
+
 	const draftPost: AppBskyDraftDefs.DraftPost = {
 		$type: 'app.bsky.draft.defs#draftPost',
 		text: postText,
@@ -178,9 +184,7 @@ function buildDraftPayload(
 				uri: externalUri,
 			},
 		];
-	}
-
-	if (quoteUri && quoteCid) {
+	} else if (quoteUri && quoteCid) {
 		draftPost.embedRecords = [
 			{
 				$type: 'app.bsky.draft.defs#draftEmbedRecord',
@@ -290,57 +294,83 @@ export async function publishDraftOperation(
 		throw new Error(`Draft with ID '${draftId}' not found.`);
 	}
 
-	const firstPost = draftView.draft.posts[0];
-	if (!firstPost) {
+	const posts = draftView.draft.posts;
+	if (!posts || posts.length === 0) {
 		throw new Error(`Draft '${draftId}' contains no posts.`);
 	}
 
-	const rt = new RichText({ text: firstPost.text });
+	const langs = draftView.draft.langs ?? [];
+	const publishedPosts: Array<{ uri: string; cid: string }> = [];
+
+	for (let index = 0; index < posts.length; index++) {
+		const draftPost = posts[index];
+
+		const rt = new RichText({ text: draftPost.text });
+		try {
+			await rt.detectFacets(agent);
+		} catch (facetsErr: any) {
+			Logger.error(
+				`Failed to detect facets in draft post ${index}: ${facetsErr?.message || facetsErr}`,
+			);
+		}
+
+		const postData: any = {
+			text: rt.text || draftPost.text,
+			langs,
+			facets: rt.facets,
+		};
+
+		if (index > 0) {
+			const rootPost = publishedPosts[0];
+			const parentPost = publishedPosts[index - 1];
+			postData.reply = {
+				root: { uri: rootPost.uri, cid: rootPost.cid },
+				parent: { uri: parentPost.uri, cid: parentPost.cid },
+			};
+		}
+
+		const externalEmbed = draftPost.embedExternals?.[0];
+		const recordEmbed = draftPost.embedRecords?.[0];
+
+		if (recordEmbed) {
+			postData.embed = {
+				$type: 'app.bsky.embed.record',
+				record: {
+					uri: recordEmbed.record.uri,
+					cid: recordEmbed.record.cid,
+				},
+			};
+		} else if (externalEmbed) {
+			postData.embed = {
+				$type: 'app.bsky.embed.external',
+				external: {
+					uri: externalEmbed.uri,
+					title: externalEmbed.uri,
+					description: '',
+				},
+			};
+		}
+
+		const postResponse: { uri: string; cid: string } = await agent.post(postData);
+		publishedPosts.push(postResponse);
+	}
+
+	let draftDeleted = true;
 	try {
-		await rt.detectFacets(agent);
-	} catch (facetsErr: any) {
-		Logger.error(`Failed to detect facets in draft text: ${facetsErr?.message || facetsErr}`);
+		await agent.app.bsky.draft.deleteDraft({ id: draftId });
+	} catch (deleteErr: any) {
+		draftDeleted = false;
+		Logger.error(
+			`Failed to delete draft '${draftId}' after publishing: ${deleteErr?.message || deleteErr}`,
+		);
 	}
 
-	const postData: any = {
-		text: rt.text || firstPost.text,
-		langs: draftView.draft.langs ?? [],
-		facets: rt.facets,
-	};
-
-	const externalEmbed = firstPost.embedExternals?.[0];
-	const recordEmbed = firstPost.embedRecords?.[0];
-
-	if (recordEmbed) {
-		postData.embed = {
-			$type: 'app.bsky.embed.record',
-			record: {
-				uri: recordEmbed.record.uri,
-				cid: recordEmbed.record.cid,
-			},
-		};
-	} else if (externalEmbed) {
-		postData.embed = {
-			$type: 'app.bsky.embed.external',
-			external: {
-				uri: externalEmbed.uri,
-				title: '',
-				description: '',
-			},
-		};
-	}
-
-	const postResponse: { uri: string; cid: string } = await agent.post(postData);
-
-	await agent.app.bsky.draft.deleteDraft({ id: draftId });
-
-	return [
-		{
-			json: {
-				uri: postResponse.uri,
-				cid: postResponse.cid,
-				draftId,
-			},
+	return publishedPosts.map((postResponse) => ({
+		json: {
+			uri: postResponse.uri,
+			cid: postResponse.cid,
+			draftId,
+			draftDeleted,
 		},
-	];
+	}));
 }

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -2,7 +2,15 @@ import { AppBskyDraftDefs, AtpAgent } from '@atproto/api';
 import { IDataObject, INodeExecutionData, INodeProperties } from 'n8n-workflow';
 import { getLanguageOptions } from './languages';
 
-type DraftPayloadInputMode = 'simple' | 'payload';
+export type DraftPayloadInputMode = 'simple' | 'payload';
+const defaultDraftPayloadJson = JSON.stringify(
+	{
+		posts: [{ text: 'Hello from draft payload' }],
+		langs: ['en'],
+	},
+	null,
+	2,
+);
 
 export const draftProperties: INodeProperties[] = [
 	{
@@ -120,8 +128,7 @@ export const draftProperties: INodeProperties[] = [
 		name: 'draftPayload',
 		type: 'string',
 		required: true,
-		default:
-			'{\n  "posts": [\n    {\n      "text": "Hello from draft payload"\n    }\n  ],\n  "langs": [\n    "en"\n  ]\n}',
+		default: defaultDraftPayloadJson,
 		typeOptions: {
 			rows: 10,
 		},
@@ -188,22 +195,35 @@ export function parseDraftPayload(rawPayload: string): AppBskyDraftDefs.Draft {
 
 	try {
 		parsedPayload = JSON.parse(rawPayload);
-	} catch {
-		throw new Error('Draft payload must be valid JSON');
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Unknown parsing error';
+		throw new Error(`Draft payload must be valid JSON: ${message}`);
 	}
 
-	if (!parsedPayload || typeof parsedPayload !== 'object' || Array.isArray(parsedPayload)) {
+	if (typeof parsedPayload !== 'object' || parsedPayload === null || Array.isArray(parsedPayload)) {
 		throw new Error('Draft payload must be a JSON object');
 	}
 
 	const payload = parsedPayload as AppBskyDraftDefs.Draft;
 
-	if (!Array.isArray(payload.posts) || payload.posts.length === 0) {
-		throw new Error('Draft payload must include a non-empty "posts" array');
+	if (payload.posts === undefined) {
+		throw new Error('Draft payload must include "posts"');
+	}
+
+	if (!Array.isArray(payload.posts)) {
+		throw new Error('Draft payload "posts" must be an array');
+	}
+
+	if (payload.posts.length === 0) {
+		throw new Error('Draft payload "posts" must not be empty');
 	}
 
 	for (const post of payload.posts) {
-		if (!post || typeof post !== 'object' || typeof post.text !== 'string') {
+		if (typeof post !== 'object' || post === null) {
+			throw new Error('Each draft post must be a JSON object');
+		}
+
+		if (typeof post.text !== 'string') {
 			throw new Error('Each draft post must include a "text" string');
 		}
 	}
@@ -225,7 +245,11 @@ export function getDraftPayloadFromInput(
 	rawPayload?: string,
 ): AppBskyDraftDefs.Draft {
 	if (mode === 'payload') {
-		return parseDraftPayload(rawPayload ?? '');
+		if (!rawPayload || !rawPayload.trim()) {
+			throw new Error('Draft payload is required when using payload mode');
+		}
+
+		return parseDraftPayload(rawPayload);
 	}
 
 	return createSimpleDraftPayload(postText, langs);

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -211,7 +211,7 @@ function buildDraftPayload(
 		draftPost.embedRecords = [
 			{
 				$type: 'app.bsky.draft.defs#draftEmbedRecord',
-				record: { uri: quoteUri, cid: quoteCid },
+				record: { uri: quoteUri!, cid: quoteCid! },
 			},
 		];
 	}

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -173,9 +173,9 @@ function buildDraftPayload(
 					cid: quoteCid,
 				}
 			: undefined;
-	const hasPartialQuote = Boolean(quoteUri) !== Boolean(quoteCid);
+	const hasIncompleteQuote = Boolean(quoteUri) !== Boolean(quoteCid);
 
-	if (hasPartialQuote) {
+	if (hasIncompleteQuote) {
 		throw new Error('Quote Post URI and Quote Post CID must be provided together.');
 	}
 

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -173,7 +173,7 @@ function buildDraftPayload(
 					cid: quoteCid,
 				}
 			: undefined;
-	const hasPartialQuote = Boolean(quoteUri || quoteCid) && !quoteRecord;
+	const hasPartialQuote = Boolean(quoteUri) !== Boolean(quoteCid);
 
 	if (hasPartialQuote) {
 		throw new Error('Quote Post URI and Quote Post CID must be provided together.');

--- a/nodes/Bluesky/V2/draftOperations.ts
+++ b/nodes/Bluesky/V2/draftOperations.ts
@@ -1,5 +1,5 @@
-import { AppBskyDraftDefs, AtpAgent } from '@atproto/api';
-import { IDataObject, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { AppBskyDraftDefs, AtpAgent, RichText } from '@atproto/api';
+import { IDataObject, INodeExecutionData, INodeProperties, LoggerProxy as Logger } from 'n8n-workflow';
 import { getLanguageOptions } from './languages';
 
 export const draftProperties: INodeProperties[] = [
@@ -33,6 +33,12 @@ export const draftProperties: INodeProperties[] = [
 				action: 'Get drafts',
 			},
 			{
+				name: 'Publish Draft',
+				value: 'publishDraft',
+				description: 'Publish a draft as a post and delete it',
+				action: 'Publish a draft',
+			},
+			{
 				name: 'Update Draft',
 				value: 'updateDraft',
 				description: 'Update an existing draft',
@@ -51,7 +57,7 @@ export const draftProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['draft'],
-				operation: ['deleteDraft', 'updateDraft'],
+				operation: ['deleteDraft', 'updateDraft', 'publishDraft'],
 			},
 		},
 	},
@@ -75,6 +81,45 @@ export const draftProperties: INodeProperties[] = [
 			'Choose from the list of supported languages. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 		options: getLanguageOptions(),
 		default: ['en'],
+		displayOptions: {
+			show: {
+				resource: ['draft'],
+				operation: ['createDraft', 'updateDraft'],
+			},
+		},
+	},
+	{
+		displayName: 'External URI',
+		name: 'draftExternalUri',
+		type: 'string',
+		default: '',
+		description: 'URL to attach as an external link embed to this draft',
+		displayOptions: {
+			show: {
+				resource: ['draft'],
+				operation: ['createDraft', 'updateDraft'],
+			},
+		},
+	},
+	{
+		displayName: 'Quote Post URI',
+		name: 'draftQuoteUri',
+		type: 'string',
+		default: '',
+		description: 'The AT-URI of the post to quote in this draft',
+		displayOptions: {
+			show: {
+				resource: ['draft'],
+				operation: ['createDraft', 'updateDraft'],
+			},
+		},
+	},
+	{
+		displayName: 'Quote Post CID',
+		name: 'draftQuoteCid',
+		type: 'string',
+		default: '',
+		description: 'The CID of the post to quote in this draft',
 		displayOptions: {
 			show: {
 				resource: ['draft'],
@@ -114,29 +159,53 @@ export const draftProperties: INodeProperties[] = [
 	},
 ];
 
-export function createSimpleDraftPayload(
+function buildDraftPayload(
 	postText: string,
 	langs: string[],
+	externalUri?: string,
+	quoteUri?: string,
+	quoteCid?: string,
 ): AppBskyDraftDefs.Draft {
+	const draftPost: AppBskyDraftDefs.DraftPost = {
+		$type: 'app.bsky.draft.defs#draftPost',
+		text: postText,
+	};
+
+	if (externalUri) {
+		draftPost.embedExternals = [
+			{
+				$type: 'app.bsky.draft.defs#draftEmbedExternal',
+				uri: externalUri,
+			},
+		];
+	}
+
+	if (quoteUri && quoteCid) {
+		draftPost.embedRecords = [
+			{
+				$type: 'app.bsky.draft.defs#draftEmbedRecord',
+				record: { uri: quoteUri, cid: quoteCid },
+			},
+		];
+	}
+
 	return {
 		$type: 'app.bsky.draft.defs#draft',
-		posts: [
-			{
-				$type: 'app.bsky.draft.defs#draftPost',
-				text: postText,
-			},
-		],
+		posts: [draftPost],
 		langs,
 	};
 }
 
 export async function createDraftOperation(
 	agent: AtpAgent,
-	draft: AppBskyDraftDefs.Draft,
+	postText: string,
+	langs: string[],
+	externalUri?: string,
+	quoteUri?: string,
+	quoteCid?: string,
 ): Promise<INodeExecutionData[]> {
-	const response = await agent.app.bsky.draft.createDraft({
-		draft,
-	});
+	const draft = buildDraftPayload(postText, langs, externalUri, quoteUri, quoteCid);
+	const response = await agent.app.bsky.draft.createDraft({ draft });
 
 	return [{ json: { id: response.data.id } }];
 }
@@ -161,8 +230,13 @@ export async function getDraftsOperation(
 export async function updateDraftOperation(
 	agent: AtpAgent,
 	draftId: string,
-	draft: AppBskyDraftDefs.Draft,
+	postText: string,
+	langs: string[],
+	externalUri?: string,
+	quoteUri?: string,
+	quoteCid?: string,
 ): Promise<INodeExecutionData[]> {
+	const draft = buildDraftPayload(postText, langs, externalUri, quoteUri, quoteCid);
 	await agent.app.bsky.draft.updateDraft({
 		draft: {
 			$type: 'app.bsky.draft.defs#draftWithId',
@@ -181,4 +255,92 @@ export async function deleteDraftOperation(
 	await agent.app.bsky.draft.deleteDraft({ id: draftId });
 
 	return [{ json: { id: draftId, deleted: true } }];
+}
+
+async function findDraftById(
+	agent: AtpAgent,
+	draftId: string,
+): Promise<AppBskyDraftDefs.DraftView | undefined> {
+	let cursor: string | undefined;
+
+	do {
+		const params: { limit: number; cursor?: string } = { limit: 100 };
+		if (cursor) {
+			params.cursor = cursor;
+		}
+
+		const response = await agent.app.bsky.draft.getDrafts(params);
+		const match = (response.data.drafts ?? []).find((d) => d.id === draftId);
+		if (match) {
+			return match;
+		}
+
+		cursor = response.data.cursor;
+	} while (cursor);
+
+	return undefined;
+}
+
+export async function publishDraftOperation(
+	agent: AtpAgent,
+	draftId: string,
+): Promise<INodeExecutionData[]> {
+	const draftView = await findDraftById(agent, draftId);
+	if (!draftView) {
+		throw new Error(`Draft with ID '${draftId}' not found.`);
+	}
+
+	const firstPost = draftView.draft.posts[0];
+	if (!firstPost) {
+		throw new Error(`Draft '${draftId}' contains no posts.`);
+	}
+
+	const rt = new RichText({ text: firstPost.text });
+	try {
+		await rt.detectFacets(agent);
+	} catch (facetsErr: any) {
+		Logger.error(`Failed to detect facets in draft text: ${facetsErr?.message || facetsErr}`);
+	}
+
+	const postData: any = {
+		text: rt.text || firstPost.text,
+		langs: draftView.draft.langs ?? [],
+		facets: rt.facets,
+	};
+
+	const externalEmbed = firstPost.embedExternals?.[0];
+	const recordEmbed = firstPost.embedRecords?.[0];
+
+	if (recordEmbed) {
+		postData.embed = {
+			$type: 'app.bsky.embed.record',
+			record: {
+				uri: recordEmbed.record.uri,
+				cid: recordEmbed.record.cid,
+			},
+		};
+	} else if (externalEmbed) {
+		postData.embed = {
+			$type: 'app.bsky.embed.external',
+			external: {
+				uri: externalEmbed.uri,
+				title: '',
+				description: '',
+			},
+		};
+	}
+
+	const postResponse: { uri: string; cid: string } = await agent.post(postData);
+
+	await agent.app.bsky.draft.deleteDraft({ id: draftId });
+
+	return [
+		{
+			json: {
+				uri: postResponse.uri,
+				cid: postResponse.cid,
+				draftId,
+			},
+		},
+	];
 }


### PR DESCRIPTION
## Summary

This PR adds support for Bluesky draft management to the V2 node by introducing operations for the Drafts API.

Implemented support includes:

- `app.bsky.draft.createDraft`
- `app.bsky.draft.getDrafts`
- `app.bsky.draft.updateDraft`
- `app.bsky.draft.deleteDraft`

## What’s included

- Added a new **Draft** resource to the Bluesky node
- Added operations for:
  - **Create Draft**
  - **Get Drafts**
  - **Update Draft**
  - **Delete Draft**
- Wired the new operations into the node execution flow
- Extended the node so draft workflows fit the existing Bluesky resource/operation structure

## Why

This repository already supports publishing and interacting with Bluesky posts, but it does not currently expose Bluesky’s draft-management endpoints. Adding draft support enables workflows such as:

- creating drafts from CMS or RSS content
- managing editorial/review pipelines before publishing
- syncing and cleaning up drafts programmatically
- building approval-based posting workflows in n8n

## Notes

- This PR focuses on draft support in the node structure
- The implementation is intended to align with the existing authentication/session flow already used by the node

## Related

- Closes / addresses issue #241