### PR TITLE
🧪 Add test for deletePostOperation

### DIFF
--- a/nodes/Bluesky/V2/__tests__/postOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/postOperations.test.ts
@@ -1,4 +1,4 @@
-import { postOperation, quoteOperation, replyOperation } from '../postOperations';
+import { deletePostOperation, postOperation, quoteOperation, replyOperation } from '../postOperations';
 import ogs from 'open-graph-scraper';
 import { AtpAgent } from '@atproto/api';
 
@@ -17,6 +17,7 @@ describe('postOperation', () => {
 		mockAgent = {
 			post: jest.fn().mockResolvedValue({ uri: 'test-uri', cid: 'test-cid' }),
 			uploadBlob: jest.fn().mockResolvedValue({ data: { blob: 'test-blob' } }),
+			deletePost: jest.fn().mockResolvedValue(undefined),
 		} as any; // Using 'any' to simplify mock structure for methods not directly used by postOperation's core logic being tested
 	});
 
@@ -152,6 +153,19 @@ describe('postOperation', () => {
 				},
 			}),
 		);
+	});
+
+	it('should delete a post', async () => {
+		const result = await deletePostOperation(mockAgent, 'at://post/to/delete');
+
+		expect(mockAgent.deletePost).toHaveBeenCalledWith('at://post/to/delete');
+		expect(result).toEqual([
+			{
+				json: {
+					uri: 'at://post/to/delete',
+				},
+			},
+		]);
 	});
 
 	it('should create a reply with root and parent refs', async () => {

--- a/nodes/Bluesky/V2/__tests__/postOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/postOperations.test.ts
@@ -1,4 +1,10 @@
-import { deletePostOperation, postOperation, quoteOperation, replyOperation } from '../postOperations';
+import {
+	deletePostOperation,
+	deleteRepostOperation,
+	postOperation,
+	quoteOperation,
+	replyOperation,
+} from '../postOperations';
 import ogs from 'open-graph-scraper';
 import { AtpAgent } from '@atproto/api';
 
@@ -18,6 +24,7 @@ describe('postOperation', () => {
 			post: jest.fn().mockResolvedValue({ uri: 'test-uri', cid: 'test-cid' }),
 			uploadBlob: jest.fn().mockResolvedValue({ data: { blob: 'test-blob' } }),
 			deletePost: jest.fn().mockResolvedValue(undefined),
+			deleteRepost: jest.fn().mockResolvedValue(undefined),
 		} as any; // Using 'any' to simplify mock structure for methods not directly used by postOperation's core logic being tested
 	});
 
@@ -209,5 +216,24 @@ describe('postOperation', () => {
 				},
 			}),
 		);
+	});
+
+	describe('deleteRepostOperation', () => {
+		it('should call deleteRepost on agent and return expected data', async () => {
+			const uri = 'at://test-repost-uri';
+
+			const result = await deleteRepostOperation(mockAgent, uri);
+
+			expect(mockAgent.deleteRepost).toHaveBeenCalledTimes(1);
+			expect(mockAgent.deleteRepost).toHaveBeenCalledWith(uri);
+
+			expect(result).toEqual([
+				{
+					json: {
+						uri,
+					},
+				},
+			]);
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `deletePostOperation` which was missing in `postOperations.test.ts`.
📊 **Coverage:** A test scenario covering the successful calling of `deletePostOperation` is now added, checking correct agent invocation and return data structure.
✨ **Result:** Enhanced test coverage around the `postOperations` module ensuring changes going forward do not cause regressions.

---
*PR created automatically by Jules for task [7175195218802152612](https://jules.google.com/task/7175195218802152612) started by @cmuench*