### PR TITLE
🧪 test: add deleteLikeOperation unit test

### DIFF
--- a/nodes/Bluesky/V2/__tests__/postOperations.test.ts
+++ b/nodes/Bluesky/V2/__tests__/postOperations.test.ts
@@ -1,4 +1,4 @@
-import { postOperation, quoteOperation, replyOperation } from '../postOperations';
+import { postOperation, quoteOperation, replyOperation, deleteLikeOperation } from '../postOperations';
 import ogs from 'open-graph-scraper';
 import { AtpAgent } from '@atproto/api';
 
@@ -195,5 +195,21 @@ describe('postOperation', () => {
 				},
 			}),
 		);
+	});
+});
+
+describe('deleteLikeOperation', () => {
+	let mockAgent: jest.Mocked<AtpAgent>;
+
+	beforeEach(() => {
+		mockAgent = {
+			deleteLike: jest.fn().mockResolvedValue(undefined),
+		} as any;
+	});
+
+	it('should call deleteLike with the provided uri and return the uri in the result', async () => {
+		const result = await deleteLikeOperation(mockAgent, 'at://like/uri');
+		expect(mockAgent.deleteLike).toHaveBeenCalledWith('at://like/uri');
+		expect(result).toEqual([{ json: { uri: 'at://like/uri' } }]);
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added a unit test for `deleteLikeOperation` in `postOperations.ts` to improve test coverage.
📊 **Coverage:** The new test covers the invocation of the agent's `deleteLike` method and validates the expected return data structure.
✨ **Result:** Enhanced reliability of the post operations by ensuring the `deleteLikeOperation` function performs as expected.

---
*PR created automatically by Jules for task [15399155339720193313](https://jules.google.com/task/15399155339720193313) started by @cmuench*